### PR TITLE
Fix usage of outdated ingress definition

### DIFF
--- a/charts/pwa/docs/migrate-to-0.3.0.md
+++ b/charts/pwa/docs/migrate-to-0.3.0.md
@@ -1,0 +1,37 @@
+# Migration to 0.3.0
+
+## What Is the Current Behavior?
+Depending on the Kubernetes version you are using, the definition of ingress resources has to be changed. If you are using Kubernetes version >= 1.19 ingress resources are now using api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Older versions of PWA Helm charts always used api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Therefore warnings like this appeared when installing in Kubernetes:
+```
+Warning:  templates/ingress.yaml: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
+```
+
+## What Is the New Behavior?
+
+We're using new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Depending on your Kubernetes version, we fallback to previous (now outdated) api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Migration of `values.yaml` has to be done by you according to these small examples.
+
+Old:
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  paths: ["/"]
+  hosts:
+    - pwa.example.local
+```
+Migrated:
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: pwa.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+```
+More information can be found in the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) of Kubernetes and the [official documentation of the ingress API object](https://kubernetes.io/docs/concepts/services-networking/ingress/).
+

--- a/charts/pwa/docs/migrate-to-0.3.0.md
+++ b/charts/pwa/docs/migrate-to-0.3.0.md
@@ -1,14 +1,14 @@
 # Migration to 0.3.0
 
 ## What Is the Current Behavior?
-Depending on the Kubernetes version you are using, the definition of ingress resources has to be changed. If you are using Kubernetes version >= 1.19 ingress resources are now using api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Older versions of PWA Helm charts always used api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Therefore warnings like this appeared when installing in Kubernetes:
+Depending on the Kubernetes version you are using, the definition of ingress resources has to be changed. If you are using Kubernetes version >= 1.19, ingress resources are now using api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Older versions of PWA Helm charts always used api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Therefore, warnings like this appeared when installing the PWA in Kubernetes:
 ```
 Warning:  templates/ingress.yaml: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
 ```
 
 ## What Is the New Behavior?
 
-We're using new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Depending on your Kubernetes version, we fallback to previous (now outdated) api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Migration of `values.yaml` has to be done by you according to these small examples.
+We are using the new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Depending on your Kubernetes version, we fall back to the previous (now outdated) api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). You have to migrate `values.yaml` according to these small examples:
 
 Old:
 ```yaml
@@ -34,4 +34,3 @@ ingress:
           pathType: ImplementationSpecific
 ```
 More information can be found in the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) of Kubernetes and the [official documentation of the ingress API object](https://kubernetes.io/docs/concepts/services-networking/ingress/).
-

--- a/charts/pwa/templates/ingress.yaml
+++ b/charts/pwa/templates/ingress.yaml
@@ -1,10 +1,21 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := (include "pwa-ingress.service" .)  }}
-{{- $ingressPaths := .Values.ingress.paths -}}
+{{- $fullName := include "pwa-ingress.service" . -}}
+{{- $svcPort := .Values.cache.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ include "pwa-main.fullname" . }}
+  name: {{ $fullName }}
   labels:
     app.kubernetes.io/name: {{ include "pwa-main.name" . }}
     helm.sh/chart: {{ include "pwa-main.chart" . }}
@@ -15,26 +26,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-	{{- range $ingressPaths }}
-          - path: {{ . }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: http
-	{{- end }}
-  {{- end }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -160,13 +160,12 @@ cache:
 
 ingress:
   enabled: true
-  className: ""
-  annotations:
-    kubernetes.io/tls-acme: "true"
-    kubernetes.io/ingress.class: nginx
-    # traefik.ingress.kubernetes.io/frontend-entry-points: https,http
+  className: nginx
+  annotations: {}
+    # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
   hosts:
-    - host: pwa.example.com
+    - host: pwa.example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -160,13 +160,16 @@ cache:
 
 ingress:
   enabled: true
+  className: ""
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
     # traefik.ingress.kubernetes.io/frontend-entry-points: https,http
-  paths: ["/"]
   hosts:
-    - example.pwa.intershop.com
+    - host: pwa.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
## PR Type
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?
Depending on the Kubernetes version you are using, the definition of ingress resources has to be changed. If you are using Kubernetes version >= 1.19 ingress resources are now using api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Older versions of PWA Helm charts always used api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Therefore warnings like this appeared when installing in Kubernetes:
```
Warning:  templates/ingress.yaml: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

## What Is the New Behavior?

We're using new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1). Depending on your Kubernetes version, we fallback to previous (now outdated) api-version [networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1). Migration of `values.yaml` has to be done by you according to these small examples. More information can be found in the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) of Kubernetes and the [official documentation of the ingress API object](https://kubernetes.io/docs/concepts/services-networking/ingress/).

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[X] Yes
[ ] No

The `hosts` configuration in `values.yaml` has to be adapted.
Old:
```yaml
ingress:
  enabled: true
  annotations:
    kubernetes.io/ingress.class: nginx
  paths: ["/"]
  hosts:
    - pwa.example.local
```
New:
```yaml
ingress:
  enabled: true
  className: nginx
  annotations: {}
    # kubernetes.io/tls-acme: "true"
    # kubernetes.io/ingress.class: nginx
  hosts:
    - host: pwa.example.local
      paths:
        - path: /
          pathType: ImplementationSpecific
```
## Other Information
