### PR TITLE
initial commit

### DIFF
--- a/charts/iom/Chart.lock
+++ b/charts/iom/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.0.19
+- name: mailhog
+  repository: https://codecentric.github.io/helm-charts
+  version: 5.0.6
+- name: iom-tests
+  repository: ""
+  version: 1.0.0
+- name: postgres
+  repository: ""
+  version: 1.0.0
+digest: sha256:90ba05364578737dcd12946c363b61c1112e66716bd99406838815d63b4aefb1
+generated: "2022-04-12T14:25:41.878022+02:00"

--- a/charts/iom/Chart.yaml
+++ b/charts/iom/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: iom
+description: A Helm chart for operation of Intershop Order Management
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 2.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 4.0.0
+
+# after changing version of a sub-chart, "helm dependency update" has to be executed
+dependencies:
+    # https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
+  - name: ingress-nginx
+    repository: https://kubernetes.github.io/ingress-nginx
+    version: 4.0.19
+    condition: nginx.enabled
+  - name: mailhog
+    # https://github.com/codecentric/helm-charts
+    repository: https://codecentric.github.io/helm-charts
+    version: 5.0.6
+    condition: mailhog.enabled
+  - name: iom-tests
+    version: 1.0.0
+    condition: iom-tests.enabled
+  - name: postgres
+    version: 1.0.0
+    condition: postgres.enabled

--- a/charts/iom/charts/iom-tests/.helmignore
+++ b/charts/iom/charts/iom-tests/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/iom/charts/iom-tests/Chart.yaml
+++ b/charts/iom/charts/iom-tests/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: iom-tests
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.0

--- a/charts/iom/charts/iom-tests/templates/NOTES.txt
+++ b/charts/iom/charts/iom-tests/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "iom-tests.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "iom-tests.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "iom-tests.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "iom-tests.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/iom/charts/iom-tests/templates/_helpers.tpl
+++ b/charts/iom/charts/iom-tests/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iom-tests.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "iom-tests.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iom-tests.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "iom-tests.labels" -}}
+helm.sh/chart: {{ include "iom-tests.chart" . }}
+{{ include "iom-tests.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iom-tests.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iom-tests.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "iom-tests.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "iom-tests.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/iom/charts/iom-tests/templates/deployment.yaml
+++ b/charts/iom/charts/iom-tests/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "iom-tests.fullname" . }}
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "iom-tests.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "iom-tests.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "iom-tests.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      containers:
+        - name: {{ .Chart.Name }}
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- if .Values.env }}
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/iom/charts/iom-tests/templates/hpa.yaml
+++ b/charts/iom/charts/iom-tests/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "iom-tests.fullname" . }}
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "iom-tests.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/iom/charts/iom-tests/templates/ingress.yaml
+++ b/charts/iom/charts/iom-tests/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "iom-tests.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/iom/charts/iom-tests/templates/service.yaml
+++ b/charts/iom/charts/iom-tests/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iom-tests.fullname" . }}
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "iom-tests.selectorLabels" . | nindent 4 }}

--- a/charts/iom/charts/iom-tests/templates/serviceaccount.yaml
+++ b/charts/iom/charts/iom-tests/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "iom-tests.serviceAccountName" . }}
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/iom/charts/iom-tests/templates/tests/test-connection.yaml
+++ b/charts/iom/charts/iom-tests/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "iom-tests.fullname" . }}-test-connection"
+  labels:
+    {{- include "iom-tests.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "iom-tests.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/iom/charts/iom-tests/values.yaml
+++ b/charts/iom/charts/iom-tests/values.yaml
@@ -1,0 +1,87 @@
+# Default values for iom-tests.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+enabled: false
+
+replicaCount: 1
+
+image:
+  repository: iom-tests
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart version.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+        
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+containerPort: 8080
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/iom/charts/postgres/.helmignore
+++ b/charts/iom/charts/postgres/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/iom/charts/postgres/Chart.yaml
+++ b/charts/iom/charts/postgres/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: postgres
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: "12"

--- a/charts/iom/charts/postgres/templates/NOTES.txt
+++ b/charts/iom/charts/postgres/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "postgres.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "postgres.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "postgres.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "postgres.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/iom/charts/postgres/templates/_helpers.tpl
+++ b/charts/iom/charts/postgres/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "postgres.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "postgres.labels" -}}
+helm.sh/chart: {{ include "postgres.chart" . }}
+{{ include "postgres.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "postgres.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "postgres.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/iom/charts/postgres/templates/deployment.yaml
+++ b/charts/iom/charts/postgres/templates/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  # number of replicas is fixed! We cannot handle a postgres cluster
+  # this way
+  replicas: 1
+
+  selector:
+    matchLabels:
+      {{- include "postgres.selectorLabels" . | nindent 6 }}
+  # there must not be two running postgres processes accessing the same data!
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "postgres.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "postgres.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.persistence.hostPath }}
+      # Before usage, owner and group have to be changed!
+      - name: docker-mount-hack
+        image: busybox
+        command: ["sh", "-c", "chown -R 999:999 /pgdata"]
+        volumeMounts:
+        - name: pgdata
+          mountPath: /pgdata
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+            exec:
+              command:
+                - su
+                - postgres
+                - "-c"
+                - pg_isready
+          readinessProbe:
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 1
+            successThreshold: 1
+            exec:
+              command:
+                - su
+                - postgres
+                - "-c"
+                - pg_isready
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          args: 
+            {{- toYaml .Values.args | nindent 12 }}
+          env:
+          
+            {{- if .Values.pg }}
+              {{- /* userSecretKeyRef has precedence over user */ -}}
+              {{- if .Values.pg.userSecretKeyRef }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                {{- toYaml .Values.pg.userSecretKeyRef | nindent 18 }}
+              {{- else if .Values.pg.user }}
+            - name: POSTGRES_USER
+              value: {{ .Values.pg.user }}
+              {{- end }}
+              {{- if .Values.pg.db }}
+            - name: POSTGRES_DB
+              value: {{ .Values.pg.db }}
+              {{- end }}
+              {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+              {{- if .Values.pg.passwdSecretKeyRef }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                {{- toYaml .Values.pg.passwdSecretKeyRef | nindent 18 }}
+              {{- else if .Values.pg.passwd }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.pg.passwd }}
+              {{- end }}
+            {{- end }}
+
+            # PostgreSQL data are not written into /var/pgdata directly. Since /var/pgdata is a mount point, it may
+            # contain other files/directories too, e.g. lost+found. In this case, PostgreSQL server would not be able
+            # to initialize the database.
+            - name: PGDATA
+              value: /var/pgdata/data
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/pgdata
+      volumes:
+      - name: pgdata
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "postgres.fullname" . }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+            
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/iom/charts/postgres/templates/ingress.yaml
+++ b/charts/iom/charts/postgres/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "postgres.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/iom/charts/postgres/templates/pvc.yaml
+++ b/charts/iom/charts/postgres/templates/pvc.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.persistence.enabled }}
+  {{- if .Values.persistence.hostPath }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ include "postgres.fullname" . }}-data
+provisioner: docker.io/hostpath
+volumeBindingMode: WaitForFirstConsumer
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: {{ include "postgres.fullname" . }}
+spec:
+  capacity:
+    storage: {{ .Values.persistence.storageSize }}
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ include "postgres.fullname" . }}-data
+  hostPath:
+    path: {{ .Values.persistence.hostPath }}
+---
+  {{- end }}
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+  {{- if .Values.persistence.annotations }}
+    {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+  name: {{ template "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storageSize | quote }}
+  {{- if .Values.persistence.hostPath }}
+  storageClassName: {{ include "postgres.fullname" . }}-data
+  {{- else }}
+    {{- if .Values.persistence.storageClass }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+      {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/iom/charts/postgres/templates/service.yaml
+++ b/charts/iom/charts/postgres/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "postgres.selectorLabels" . | nindent 4 }}

--- a/charts/iom/charts/postgres/templates/serviceaccount.yaml
+++ b/charts/iom/charts/postgres/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "postgres.serviceAccountName" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/iom/charts/postgres/templates/tests/test-connection.yaml
+++ b/charts/iom/charts/postgres/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "postgres.fullname" . }}-test-connection"
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "postgres.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/iom/charts/postgres/values.yaml
+++ b/charts/iom/charts/postgres/values.yaml
@@ -1,0 +1,94 @@
+# Default values for postgres.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+enabled: false
+
+# postgres command line arguments
+args: ["-N", "200", "-c", "max_prepared_transactions=100"]
+
+# required for NOTES.txt only
+ingress:
+  enabled: false
+
+image:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart version.
+  # tag: "12"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# general postgres settings, required to connect to postgres server
+# and root db.
+pg:
+  user:               postgres
+  userSecretKeyRef:
+  passwd:             postgres
+  passwdSecretKeyRef:
+  db:                 postgres
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 5432
+
+persistence:
+  # postgres data are written to memory only
+  enabled: false
+  # ignored, if hostPath is set.
+  accessMode: ReadWriteOnce
+  # ignored, if hostPath is set.
+  # If defined, storageClass: <storageClass>
+  # If set to "-", storageClass: "", which disables dynamic provisioning
+  # If undefined (the default) or set to null, no storageClass spec is
+  #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  #   GKE, AWS & OpenStack)
+  storageClass:
+  # ignored, if hostPath is set.
+  annotations:
+  storageSize: 20Gi
+  # To be used in simple environments (e.g. demos) to persist data on local host.
+  hostPath:
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+

--- a/charts/iom/templates/NOTES.txt
+++ b/charts/iom/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "iom.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "iom.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "iom.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "iom.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/iom/templates/_helpers.tpl
+++ b/charts/iom/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iom.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "iom.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iom.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "iom.labels" -}}
+helm.sh/chart: {{ include "iom.chart" . }}
+{{ include "iom.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iom.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iom.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "iom.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "iom.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/iom/templates/connection-monitor.yaml
+++ b/charts/iom/templates/connection-monitor.yaml
@@ -1,0 +1,127 @@
+{{- if and (.Values.oms.db.connectionMonitor.enabled) (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: batch/v1
+{{- else if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: batch/v1beta1
+{{-  end }}
+kind: CronJob
+metadata:
+  name: {{ include "iom.fullname" . }}-connection-monitor
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.oms.db.connectionMonitor.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: connection-monitor
+            {{- if .Values.config.enabled }}
+            image: "{{ .Values.config.image.repository }}:{{ .Values.config.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.config.image.pullPolicy }}
+            {{- else }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- end }}
+            env:
+            {{- if .Values.postgres.enabled }}
+            #
+            # database settings, is sub-chart postgres is enabled
+            #
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: ''
+            - name: OMS_DB_HOST
+              value: {{ .Release.Name }}-postgres
+            - name: OMS_DB_PORT
+              value: '5432'
+            {{- else }}
+            #
+            # database settings, if sub-chart postgres is disabled
+            #
+              {{- if .Values.pg }}
+                {{- if .Values.pg.userConnectionSuffix }}
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: '{{ .Values.pg.userConnectionSuffix }}'
+                {{- end }}
+                {{- if .Values.pg.host }}
+            - name: OMS_DB_HOST
+              value: {{ .Values.pg.host }}
+                {{- end }}
+                {{- if .Values.pg.port }}
+            - name: OMS_DB_PORT
+              value: '{{ .Values.pg.port }}'
+                {{- end }}
+                {{- if .Values.pg.sslMode }}
+            - name: PGSSL_MODE
+              value: '{{ .Values.pg.sslMode }}'
+                {{- end }}
+                {{- if .Values.pg.sslCompression }}
+            - name: PGSSL_COMPRESSION
+              value: '{{ .Values.pg.sslCompression }}'
+                {{- end }}
+                {{- if .Values.pg.sslRootCert }}
+            - name: PGSSL_ROOTCERT
+              value: '{{ .Values.pg.sslRootCert | b64enc }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # common database settings
+            #
+            {{- if .Values.oms }}
+              {{- if .Values.oms.db }}
+                {{- if .Values.oms.db.name }}
+            - name: OMS_DB_NAME
+              value: {{ .Values.oms.db.name }}
+                {{- end }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.oms.db.userSecretKeyRef }}
+            - name: OMS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.user }}
+            - name: OMS_DB_USER
+              value: {{ .Values.oms.db.user }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                {{- if .Values.oms.db.passwdSecretKeyRef }}
+            - name: OMS_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.passwd }}
+            - name: OMS_DB_PASS
+              value: {{ .Values.oms.db.passwd }}
+                {{- end }}
+                {{- if .Values.oms.db.connectTimeout }}
+            - name: OMS_DB_CONNECT_TIMEOUT
+              value: '{{ .Values.oms.db.connectTimeout }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.log }}
+            #
+            # log settings
+            #
+            - name: OMS_LOGLEVEL_SCRIPTS
+              value: INFO
+              {{- if .Values.log.metadata }}
+                {{- if .Values.log.metadata.tenant }}
+            - name: TENANT
+              value: {{ .Values.log.metadata.tenant }}
+                {{- end }}
+                {{- if .Values.log.metadata.environment }}
+            - name: ENVIRONMENT
+              value: {{ .Values.log.metadata.environment }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.config.enabled }}
+            command: [ '/opt/connection_monitor.sh' ]
+            {{- else }}
+            command: [ '/opt/oms/bin/connection_monitor.sh' ]
+            {{- end }}
+          restartPolicy: Never
+{{- end }}

--- a/charts/iom/templates/ingress-internal-proxy.yaml
+++ b/charts/iom/templates/ingress-internal-proxy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.nginx.enabled .Values.nginx.proxy.enabled -}}
+{{- $fullName := include "iom.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-internal-nginx
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.nginx.proxy.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+    kubernetes.io/ingress.class: "nginx-iom"    
+    {{- end }}
+    # a proxy should not do ssl-redirect
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # https://github.com/kubernetes/ingress-nginx/issues/3989
+    # it's necessary to have a matching host-rule in order to get session-affinity working
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-path: "/omt"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: nginx-iom
+  {{- end }}
+  # a proxy does not need any certificates
+  rules:
+    # send any URL to IOM
+    - http:
+        paths:
+          - path: "/"
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+{{- end }}

--- a/charts/iom/templates/ingress.yaml
+++ b/charts/iom/templates/ingress.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "iom.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- /* if integrated nginx ingress controller is enabled and working as a proy, this web-server will be responsible for session-affinity */ -}}
+  {{- if not ( and .Values.nginx.enabled .Values.nginx.proxy.enabled )}}
+    #
+    # provide session affinity
+    #
+    # https://github.com/kubernetes/ingress-nginx/issues/3989
+    # it's necessary to have a matching host-rule in order to get session-affinity working?
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-path: "/omt"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- /* if internal nginx is enabled and acting as a proxy, the incoming requests have to be forwarded to this web-server, */ -}}
+  {{- /* instead of IOM application servers directly. */ -}}
+  {{- if and .Values.nginx.enabled .Values.nginx.proxy.enabled }}
+    {{- $release := .Release.Name -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: "{{ $release }}-ingress-nginx-controller"
+                port:
+                  number: 80
+              {{- else }}
+              serviceName: "{{ $release }}-ingress-nginx-controller"
+              servicePort: 80
+              {{- end }}
+              {{- /* port cannot be accessed by variable name, since ingress-nginx contains a -, */ -}}
+              {{- /* which is not allowed in variable names. Otherwise it would be possible to   */ -}}
+              {{- /* use .Values.ingress-nginx.controller.service.ports.http                     */ -}}
+          {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/charts/iom/templates/patch-downtime.yaml
+++ b/charts/iom/templates/patch-downtime.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.downtime (ne (quote .Values.replicaCount) "1") -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iom-patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: iom-patch
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: iom-patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: iom-patch
+subjects:
+- kind: ServiceAccount
+  name: iom-patch
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: iom-patch
+      containers:
+      - name: patch-replica-count
+        image: "bitnami/kubectl"
+        args: 
+        - patch 
+        - --type=merge 
+        - sts 
+        - {{ include "iom.fullname" . }} 
+        - -n
+        - {{ .Release.Namespace }} 
+        - -p
+        - '{"spec":{"replicas":{{ .Values.replicaCount }}}}'
+{{- end }}

--- a/charts/iom/templates/patch-mailhog.yaml
+++ b/charts/iom/templates/patch-mailhog.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.mailhog.enabled (not .Values.mailhog.probes.enabled) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mailhog-patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mailhog-patch
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mailhog-patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mailhog-patch
+subjects:
+- kind: ServiceAccount
+  name: mailhog-patch
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-mailhog-patch"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-mailhog-patch"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: mailhog-patch
+      containers:
+      - name: patch-mailhog-probes
+        image: "bitnami/kubectl"
+        args: 
+        - patch
+        - deployment
+        - {{ .Release.Name }}-mailhog
+        - --namespace={{ .Release.Namespace }}
+        - --type=json
+        - -p
+        - '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},{"op":"remove","path":"/spec/template/spec/containers/0/readinessProbe"}]'
+{{- end }}

--- a/charts/iom/templates/persistentvolumeclaim.yaml
+++ b/charts/iom/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,53 @@
+{{- if not .Values.persistence.pvc }}
+  {{- if .Values.persistence.hostPath }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ include "iom.fullname" . }}-share
+provisioner: docker.io/hostpath
+volumeBindingMode: WaitForFirstConsumer
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: {{ include "iom.fullname" . }}
+spec:
+  capacity:
+    storage: {{ .Values.persistence.storageSize }}
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ include "iom.fullname" . }}-share
+  hostPath:
+    path: {{ .Values.persistence.hostPath }}
+---
+  {{- end }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+  {{- if hasKey .Values.persistence "annotations" }}
+    {{- if .Values.persistence.annotations }}
+      {{- toYaml .Values.persistence.annotations | nindent 4 }}
+    {{- end }}
+  {{- else }}
+    # default annotations are guaranteeing, that persistent volumes are not deleted
+    # by running helm delete
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": pre-install
+  {{- end }}
+  name: {{ include "iom.fullname" . }}
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  {{- if .Values.persistence.hostPath }}
+  storageClassName: {{ include "iom.fullname" . }}-share
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storageSize }}
+{{- end }}

--- a/charts/iom/templates/service.yaml
+++ b/charts/iom/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iom.fullname" . }}
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "iom.selectorLabels" . | nindent 4 }}

--- a/charts/iom/templates/serviceaccount.yaml
+++ b/charts/iom/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "iom.serviceAccountName" . }}
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/iom/templates/statefulset.yaml
+++ b/charts/iom/templates/statefulset.yaml
@@ -1,0 +1,995 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "iom.fullname" . }}
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+spec:
+  podManagementPolicy: OrderedReady
+  serviceName: {{ include "iom.fullname" . }}
+  # after "helm upgrade" the replicaCount has to be restored, e.g. by executing:
+  # kubectl patch --type=merge sts $(release) -n $(namespace) -p '{"spec":{"replicas": $(replicaCount)}}'
+  replicas: {{ if .Values.downtime }}{{ 1 }}{{ else }}{{ .Values.replicaCount }}{{ end }}
+  selector:
+    matchLabels:
+      {{- include "iom.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "iom.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "iom.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # overwrite command defined by Dockerfile
+          # Only instance with hostname ending with -0 is executing the backend-applications.
+          {{- if not (kindIs "bool" .Values.oms.execBackendApps) }}
+            {{ fail "oms.execBackendApps contains a non boolean value!" }}
+          {{- end }}
+          {{- if .Values.config.enabled }}
+          command:
+            - /bin/sh
+            - "-c"
+            - export OMS_EXEC_BACKEND_APPS=false; if hostname -s | grep -q -- '-0$'; then export OMS_EXEC_BACKEND_APPS={{ .Values.oms.execBackendApps }}; fi; $OMS_HOME/bin/wildfly_start.sh
+          {{- else }}
+          args: [ "--run-in-statefulset" ]
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /monitoring/services/health/status
+              port: http
+              scheme: HTTP
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- if and .Values.startupProbe.enabled (not .Values.config.enabled) }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: 1
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- if and .Values.datadogApm.enabled }}
+            #
+            # datadog APM agent settings
+            # see https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm
+            # see https://app.datadoghq.eu/apm/docs?architecture=container-based&collection=Helm%20Chart%20%28Recommended%29&environment=kubernetes&language=java
+            # see https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/?tab=log4j2
+            # see https://docs.datadoghq.com/tracing/troubleshooting/
+            # see https://docs.datadoghq.com/tracing/troubleshooting/tracer_debug_logs/
+            # see https://docs.datadoghq.com/tracing/troubleshooting/tracer_startup_logs/
+            # see https://docs.datadoghq.com/tracing/setup_overview/setup/java?tab=jboss
+            # see https://docs.datadoghq.com/getting_started/agent/autodiscovery/?tab=kubernetes
+            # see https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/
+            #
+            - name: DD_APM_ENABLED
+              value: 'true'
+            - name: DD_APM_BACKEND_ONLY
+              {{- if .Values.datadogApm.backendOnly }}
+                {{- if not (kindIs "bool" .Values.datadogApm.backendOnly) }}
+                  {{ fail "datadogApm.backendOnly contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+              {{- if .Values.datadogApm.traceAgentHost }}
+            - name: DD_AGENT_HOST
+              value: '{{ .Values.datadogApm.traceAgentHost }}'
+              {{- end }}
+              {{- if .Values.datadogApm.traceAgentPort }}
+            - name: DD_TRACE_AGENT_PORT
+              value: '{{ .Values.datadogApm.traceAgentPort }}'
+              {{- end }}
+              {{- if .Values.datadogApm.traceAgentTimeout }}
+            - name: DD_TRACE_AGENT_TIMEOUT
+              value: '{{ .Values.datadogApm.traceAgentTimeout }}'
+              {{- end }}
+            - name: DD_LOGS_INJECTION
+              {{- if .Values.datadogApm.logsInjection }}
+                {{- if not (kindIs "bool" .Values.datadogApm.logsInjection) }}
+                  {{ fail "datadogApm.logsInjection contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: DD_TRACE_DEBUG
+              {{- if .Values.datadogApm.debug }}
+                {{- if not (kindIs "bool" .Values.datadogApm.debug) }}
+                  {{ fail "datadogApm.debug contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: DD_TRACE_STARTUP_LOGS
+              {{- if .Values.datadogApm.startupLogs }}
+                {{- if not (kindIs "bool" .Values.datadogApm.startupLogs) }}
+                  {{ fail "datadogApm.startupLogs contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+              {{- if .Values.datadogApm.tags }}
+            - name: DD_TAGS
+              value: '{{ .Values.datadogApm.tags }}'
+              {{- end }}
+            - name: DD_SERVICE_MAPPING
+              # TODO: where comes service name from?
+              # TODO: is service name postgresql is valid only, if internal postgres is used?
+              {{- if .Values.datadogApm.serviceMapping }}
+              value: '{{ .Values.datadogApm.serviceMapping }}'
+              {{- end }}
+              {{- if .Values.datadogApm.writerType }}
+            - name: DD_WRITER_TYPE
+              value: '{{ .Values.datadogApm.writerType }}'
+              {{- end }}
+              {{- if .Values.datadogApm.partialFlushMinSpans }}
+            - name: DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+              value: '{{ .Values.datadogApm.partialFlushMinSpans }}'
+              {{- end }}
+              {{- if .Values.datadogApm.dbClientSplitByInstance }}
+            - name: DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE
+              value: '{{ .Values.datadogApm.dbClientSplitByInstance }}'
+              {{- end }}
+            - name: DD_TRACE_HEALTH_METRICS_ENABLED
+              {{- if .Values.datadogApm.healthMetricsEnabled }}
+                {{- if not (kindIs "bool" .Values.datadogApm.healthMetricsEnabled) }}
+                  {{ fail "datadogApm.healthMetricsEnabled contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: DD_TRACE_SERVLET_ASYNC_TIMEOUT_ERROR
+              {{- if .Values.datadogApm.servletAsyncTimeoutError }}
+                {{- if not (kindIs "bool" .Values.datadogApm.servletAsyncTimeoutError) }}
+                  {{ fail "datadogApm.servletAsyncTimeoutError contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+              {{- if .Values.datadogApm.sampleRate }}
+            - name: DD_TRACE_SAMPLE_RATE
+              value: '{{ .Values.datadogApm.sampleRate }}'
+              {{- end }}
+            - name: DD_JMXFETCH_ENABLED
+              {{- if .Values.datadogApm.jmxFetchEnabled }}
+                {{- if not (kindIs "bool" .Values.datadogApm.jmxFetchEnabled) }}
+                  {{ fail "datadogApm.jmxFetchEnabled contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            {{- end }}
+            {{- if .Values.postgres.enabled }}
+            #
+            # database settings, if sub-chart postgres is enabled
+            #
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: ''
+            - name: OMS_DB_HOSTLIST
+              value: {{ .Release.Name }}-postgres:5432
+            
+            # database settings, that were migrated from config image
+            
+              {{- if not .Values.config.enabled }}
+            - name: OMS_DB_HOST
+              value: {{ .Release.Name }}-postgres
+            - name: OMS_DB_PORT
+              value: '5432'
+              {{- end }}
+            {{- else }}
+            #
+            # database settings, if sub-chart postgres is disabled
+            #
+              {{- if .Values.pg }}
+                {{- if .Values.pg.userConnectionSuffix }}
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: '{{ .Values.pg.userConnectionSuffix }}'
+                {{- end}}
+                {{- if and .Values.pg.host .Values.pg.port ( not .Values.oms.db.hostlist ) }}
+            - name: OMS_DB_HOSTLIST
+              value: {{ .Values.pg.host }}:{{ .Values.pg.port }}
+                {{- else if .Values.oms.db.hostlist }}
+            - name: OMS_DB_HOSTLIST
+              value: {{ .Values.oms.db.hostlist }}
+                {{- end }}
+              {{- end }}
+              
+              # database settings, that were migrated from config image
+              
+              {{- if not .Values.config.enabled }}
+                {{- if .Values.pg.host }}
+            - name: OMS_DB_HOST
+              value: {{ .Values.pg.host }}
+                {{- end }}
+                {{- if .Values.pg.port }}
+            - name: OMS_DB_PORT
+              value: '{{ .Values.pg.port }}'
+                {{- end }}
+                {{- if .Values.pg.sslMode }}
+            - name: PGSSL_MODE
+              value: '{{ .Values.pg.sslMode }}'
+                {{- end }}
+                {{- if .Values.pg.sslCompression }}
+            - name: PGSSL_COMPRESSION
+              value: '{{ .Values.pg.sslCompression }}'
+                {{- end }}
+                {{- if .Values.pg.sslRootCert }}
+            - name: PGSSL_ROOTCERT
+              value: '{{ .Values.pg.sslRootCert | b64enc }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # common database settings
+            #
+            {{- if .Values.oms }}
+              {{- if .Values.oms.db }}
+                {{- if .Values.oms.db.name }}
+            - name: OMS_DB_NAME
+              value: {{ .Values.oms.db.name }}
+                {{- end }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.oms.db.userSecretKeyRef }}
+            - name: OMS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.user }}
+            - name: OMS_DB_USER
+              value: {{ .Values.oms.db.user }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                {{- if .Values.oms.db.passwdSecretKeyRef }}
+            - name: OMS_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.passwd }}
+            - name: OMS_DB_PASS
+              value: {{ .Values.oms.db.passwd }}
+                {{- end }}
+                {{- if .Values.oms.db.connectTimeout }}
+            - name: OMS_DB_CONNECT_TIMEOUT
+              value: '{{ .Values.oms.db.connectTimeout }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if not .Values.config.enabled }}
+              {{- if .Values.oms }}
+            #
+            # PlatformConfigProperties
+            #
+                {{- if .Values.oms.archiveOrderMessageLogMinAge }}
+            - name: OMS_ARCHIVE_ORDERMSGLOG_MIN_AGE
+              value: '{{ .Values.oms.archiveOrderMessageLogMinAge }}'
+                {{- end }}
+                {{- if .Values.oms.deleteOrderMessageLogMinAge }}
+            - name: OMS_DELETE_ORDERMSGLOG_MIN_AGE
+              value: '{{ .Values.oms.deleteOrderMessageLogMinAge }}'
+                {{- end }}
+                {{- if .Values.oms.archiveShopCustomerMailMinAge }}
+            - name: OMS_ARCHIVE_SHOPCUSTMAIL_MIN_AGE
+              value: '{{ .Values.oms.archiveShopCustomerMailMinAge }}'
+                {{- end }}
+                {{- if .Values.oms.archiveShopCustomerMailMaxCount }}
+            - name: OMS_ARCHIVE_SHOPCUSTMAIL_MAX_COUNT
+              value: '{{ .Values.oms.archiveShopCustomerMailMaxCount }}'
+                {{- end }}
+                {{- if .Values.oms.deleteShopCustomerMailMinAge }}
+            - name: OMS_DELETE_SHOPCUSTMAIL_MIN_AGE
+              value: '{{ .Values.oms.deleteShopCustomerMailMinAge }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.mailhog.enabled }}
+            #
+            # SMTP settings, if sub-chart mailhog is enabled
+            #
+            - name: OMS_SMTP_HOST
+              value: {{ .Release.Name }}-mailhog
+            - name: OMS_SMTP_PORT
+              value: '1025'
+            - name: OMS_SMTP_USER
+              value: ''
+            - name: OMS_SMTP_PASS
+              value: ''
+            {{- else }}
+            #
+            # SMTP settings, if sub-chart mailhog is disabled
+            #
+              {{- if .Values.oms }}
+                {{- if .Values.oms.smtp }}
+                  {{- if .Values.oms.smtp.host }}
+            - name: OMS_SMTP_HOST
+              value: {{ .Values.oms.smtp.host }}
+                  {{- end }}
+                  {{- if .Values.oms.smtp.port }}
+            - name: OMS_SMTP_PORT
+              value: '{{ .Values.oms.smtp.port }}'
+                  {{- end }}
+                  {{- /* userSecretKeyRef has precedence over user */ -}}
+                  {{- if .Values.oms.smtp.userSecretKeyRef }}
+            - name: OMS_SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                    {{- toYaml .Values.oms.smtp.userSecretKeyRef | nindent 18 }}
+                  {{- else if .Values.oms.smtp.user }}
+            - name: OMS_SMTP_USER
+              value: {{ .Values.oms.smtp.user }}
+                  {{- end }}
+                  {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                  {{- if .Values.oms.smtp.passwdSecretKeyRef }}
+            - name: OMS_SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                    {{- toYaml .Values.oms.smtp.passwdSecretKeyRef | nindent 18 }}
+                  {{- else if .Values.oms.smtp.passwd }}
+            - name: OMS_SMTP_PASS
+              value: {{ .Values.oms.smtp.passwd }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # general OMS settings
+            #
+            {{- if .Values.oms }}
+              {{- if .Values.oms.publicUrl }}
+            - name: OMS_PUBLIC_URL
+              value: {{ .Values.oms.publicUrl }}
+              {{- end }}
+              {{- if .Values.oms.mailResourcesBaseUrl }}
+            - name: OMS_MAIL_RESOURCES_BASE_URL
+              value: {{ .Values.oms.mailResourcesBaseUrl }}
+              {{- end }}
+              {{- /* jwtSecretKeyRef has precedence over jwtSecret */ -}}
+              {{- if .Values.oms.jwtSecretKeyRef }}
+            - name: OMS_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                {{- toYaml .Values.oms.jwtSecretKeyRef | nindent 18 }}
+              {{- else if .Values.oms.jwtSecret }}
+            - name: OMS_JWT_SECRET
+              value: {{ .Values.oms.jwtSecret }}
+              {{- end }}
+            - name: OMS_SECURE_COOKIES_ENABLED
+              {{- if .Values.oms.secureCookiesEnabled }}
+                {{- if not (kindIs "bool" .Values.oms.secureCookiesEnabled) }}
+                  {{ fail "oms.secureCookiesEnabled contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: OMS_EXEC_BACKEND_APPS
+              {{- if .Values.oms.execBackendApps }}
+                {{- if not (kindIs "bool" .Values.oms.execBackendApps) }}
+                  {{ fail "oms.execBackendApps contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            {{- end }}
+            #
+            # other settings, that were migrated from config image
+            #
+            {{- if not .Values.config.enabled }}
+            - name: DB_READY_TIMEOUT
+              value: '300'
+            {{- end }}
+            {{- if .Values.jboss }}
+            #
+            # jboss settings
+            #
+              {{- if or .Values.jboss.javaOpts .Values.jboss.javaOptsAppend }}
+            - name: JBOSS_JAVA_OPTS
+              value: {{ .Values.jboss.javaOpts }} {{ .Values.jboss.javaOptsAppend }}
+              {{- end }}
+              {{- if .Values.jboss.opts }}
+            - name: JBOSS_OPTS
+              value: {{ .Values.jboss.opts }}
+              {{- end }}
+              {{- if .Values.jboss.xaPoolsizeMin }}
+            - name: JBOSS_XA_POOLSIZE_MIN
+              value: '{{ .Values.jboss.xaPoolsizeMin }}'
+              {{- end }}
+              {{- if .Values.jboss.xaPoolsizeMax }}
+            - name: JBOSS_XA_POOLSIZE_MAX
+              value: '{{ .Values.jboss.xaPoolsizeMax }}'
+              {{- end }}
+              {{- if .Values.jboss.activemqClientPoolSizeMax }}
+            - name: JBOSS_ACTIVEMQ_CLIENT_POOLSIZE_MAX
+              value: '{{ .Values.jboss.activemqClientPoolSizeMax }}'
+              {{- end }}
+              {{- if .Values.jboss.nodePrefix }}
+            - name: JBOSS_NODE_PREFIX
+              value: '{{ .Values.jboss.nodePrefix }}'
+              {{- end }}
+            {{- end }}
+            {{- if .Values.log }}
+            #
+            # log settings
+            #
+              {{- if .Values.log.access }}
+            - name: OMS_ACCESS_LOG_ENABLED
+                {{- if .Values.log.access.enabled }}
+                  {{- if not (kindIs "bool" .Values.log.access.enabled) }}
+                    {{ fail "log.access.enabled contains a non boolean value!" }}
+                  {{- end }}
+              value: 'true'
+                {{- else }}
+              value: 'false'
+                {{- end }}
+              {{- end }}
+              {{- if .Values.log.level }}
+                {{- if .Values.log.level.console }}
+            - name: OMS_LOGLEVEL_CONSOLE
+              value: {{ .Values.log.level.console }}
+                {{- end }}
+                {{- if .Values.log.level.iom }}
+            - name: OMS_LOGLEVEL_IOM
+              value: {{ .Values.log.level.iom }}
+                {{- end }}
+                {{- if .Values.log.level.hibernate }}
+            - name: OMS_LOGLEVEL_HIBERNATE
+              value: {{ .Values.log.level.hibernate }}
+                {{- end }}
+                {{- if .Values.log.level.quartz }}
+            - name: OMS_LOGLEVEL_QUARTZ
+              value: {{ .Values.log.level.quartz }}
+                {{- end }}
+                {{- if .Values.log.level.activeMQ }}
+            - name: OMS_LOGLEVEL_ACTIVEMQ
+              value: {{ .Values.log.level.activeMQ }}
+                {{- end }}
+                {{- if .Values.log.level.customization }}
+            - name: OMS_LOGLEVEL_CUSTOMIZATION
+              value: {{ .Values.log.level.customization }}
+                {{- end }}
+                {{- if .Values.log.level.scripts }}
+            - name: OMS_LOGLEVEL_SCRIPTS
+              value: {{ .Values.log.level.scripts }}
+                {{- end }}
+              {{- end }}
+              {{- if .Values.log.metadata }}
+                {{- if .Values.log.metadata.tenant }}
+            - name: TENANT
+              value: {{ .Values.log.metadata.tenant }}
+                {{- end }}
+                {{- if .Values.log.metadata.environment }}
+            - name: ENVIRONMENT
+              value: {{ .Values.log.metadata.environment }}
+                {{- end }}
+              {{- end }}
+              {{- if .Values.log.rest }}
+            - name: OMS_LOG_REST_IDS
+              value: {{ join "," .Values.log.rest }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.project }}
+            #
+            # project settings
+            #
+              {{- if .Values.project.envName }}
+                {{- if .Values.config.enabled }}
+            - name: CAAS_ENV_NAME
+                {{- else }}
+            - name: PROJECT_ENV_NAME
+                {{- end }}
+              value: {{ .Values.project.envName }}
+              {{- end }}
+              {{- if .Values.config.enabled }}
+            - name: CAAS_IMPORT_TEST_DATA
+              {{- else }}
+            - name: PROJECT_IMPORT_TEST_DATA
+              {{- end }}
+              {{- if and .Values.project.importTestData .Release.IsInstall }}
+                {{- if not (kindIs "bool" .Values.project.importTestData) }}
+                  {{ fail "project.importTestData contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+              {{- if .Values.project.importTestDataTimeout }}
+                {{- if .Values.config.enabled }}
+            - name: CAAS_IMPORT_TEST_DATA_TIMEOUT
+                {{- else }}
+            - name: PROJECT_IMPORT_TEST_DATA_TIMEOUT
+                {{- end }}
+              value: '{{ .Values.project.importTestDataTimeout }}'
+              {{- end }}
+            {{- end }}
+            #
+            # fixed settings
+            #
+            # deprecated: OMS_SHAREDFS_HEALTHCHECK was removed in IOM 3.1. For backward compatibility with IOM 3.0 the
+            # variable has still to be set.
+            - name: OMS_SHAREDFS_HEALTHCHECK
+              value: disabled
+            - name: OMS_HOME
+              value: '/opt/oms'
+            - name: OMS_ETC
+              value: '/opt/oms/etc'
+            # deprecated (currently still needed by IOM-Forrester-2020)
+            - name: OMS_SHARE
+              value: '/var/opt/share'
+              
+          volumeMounts:
+            - name: app-share-volume
+              mountPath: /var/opt/share
+
+          # deprecated (currently still needed by IOM-Forrester-2020)
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - "-c"
+                  - if [ -f /opt/oms/bin/iom_start_handler.sh ]; then export OMS_EXEC_BACKEND_APPS=false; if hostname | grep -q -- '-0$'; then export OMS_EXEC_BACKEND_APPS=true; fi; /opt/oms/bin/iom_start_handler.sh; fi
+                
+      initContainers:
+        {{- if .Values.persistence.hostPath }}
+        # Before usage, owner and group have to be changed!
+        - name: docker-mount-hack
+          image: busybox
+          command: ["sh", "-c", "chown -R 1000:1000 /share"]
+          volumeMounts:
+          - name: app-share-volume
+            mountPath: /share
+        {{- end }}
+        {{- if and .Values.dbaccount.enabled .Release.IsInstall }}
+        - name: dbaccount
+          imagePullPolicy: {{ .Values.dbaccount.image.pullPolicy }}
+          image: "{{ .Values.dbaccount.image.repository }}:{{ .Values.dbaccount.image.tag }}"
+
+          # overwrites the default command defined in Dockerfile
+          # dbaccount is only executed, if hostname ends with -0, which
+          # only is the case for the first server of a stateful set.
+          command:
+            - /bin/sh
+            - "-c"
+            - if hostname | grep -q -- '-0$'; then /opt/create_dbaccount.sh; fi
+          resources:
+            {{- toYaml .Values.dbaccount.resources | nindent 12 }}
+          env:
+            {{- if .Values.postgres.enabled }}
+            #
+            # database settings, if sub-chart postgres is enabled
+            #
+              {{- if .Values.postgres.pg }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.postgres.pg.userSecretKeyRef }}
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.postgres.pg.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.postgres.pg.user }}
+            - name: PGUSER
+              value: {{ .Values.postgres.pg.user }}
+                {{- end }}
+                {{- if .Values.postgres.pg.db }}
+            - name: PGDATABASE
+              value: {{ .Values.postgres.pg.db }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                {{- if .Values.postgres.pg.passwdSecretKeyRef }}
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.postgres.pg.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.postgres.pg.passwd }}
+            - name: PGPASSWORD
+              value: {{ .Values.postgres.pg.passwd }}
+                {{- end }}
+            - name: PGHOST
+              value: {{ .Release.Name }}-postgres
+            - name: PGPORT
+              value: '5432'
+            - name: PGUSER_CONNECTION_SUFFIX
+              value: ''
+              {{- end }}
+            {{- else }}
+            #
+            # database settings, if sub-chart postgres is not enabled
+            #
+              {{- if .Values.pg }}
+                {{- if .Values.pg.sslMode }}
+            - name: PGSSL_MODE
+              value: '{{ .Values.pg.sslMode }}'
+                {{- end }}
+                {{- if .Values.pg.sslCompression }}
+            - name: PGSSL_COMPRESSION
+              value: '{{ .Values.pg.sslCompression }}'
+                {{- end }}
+                {{- if .Values.pg.sslRootCert }}
+            - name: PGSSL_ROOTCERT
+              value: '{{ .Values.pg.sslRootCert | b64enc }}'
+                {{- end }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.pg.userSecretKeyRef }}
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.pg.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.pg.user }}
+            - name: PGUSER
+              value: {{ .Values.pg.user }}
+                {{- end }}
+                {{- if .Values.pg.db }}
+            - name: PGDATABASE
+              value: {{ .Values.pg.db }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precendence over passwd */ -}}
+                {{- if .Values.pg.passwdSecretKeyRef }}
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.pg.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.pg.passwd }}
+            - name: PGPASSWORD
+              value: {{ .Values.pg.passwd }}
+                {{- end }}
+                {{- if .Values.pg.host }}
+            - name: PGHOST
+              value: {{ .Values.pg.host }}
+                {{- end }}
+                {{- if .Values.pg.port }}
+            - name: PGPORT
+              value: '{{ .Values.pg.port }}'
+                {{- end }}
+                {{- if .Values.pg.userConnectionSuffix }}
+            - name: PGUSER_CONNECTION_SUFFIX
+              value: '{{ .Values.pg.userConnectionSuffix }}'
+                {{- end }}
+                {{- if .Values.dbaccount.tablespace }}
+            - name: OMS_DB_TABLESPACE
+              value: {{ .Values.dbaccount.tablespace }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # db settings, which do not depend on .Values.postgres.enabled 
+            #
+            - name: OMS_DB_RESET
+            {{- if .Values.dbaccount.resetData }}
+              {{- if not (kindIs "bool" .Values.dbaccount.resetData) }}
+                {{ fail "dbaccount.resetData contains a non boolean value!" }}
+              {{- end }}
+              value: 'true'
+            {{- else }}
+              value: 'false'
+            {{- end }}
+            {{- if .Values.dbaccount.options }}
+            - name: OMS_DB_OPTIONS
+              value: {{ .Values.dbaccount.options }}
+            {{- end }}
+            {{- if .Values.dbaccount.searchPath }}
+            - name: OMS_DB_SEARCHPATH
+              value: {{ .Values.dbaccount.searchPath }}
+            {{- end }}
+            {{- if .Values.oms }}
+              {{- if .Values.oms.db }}
+                {{- if .Values.oms.db.name }}
+            - name: OMS_DB_NAME
+              value: {{ .Values.oms.db.name }}
+                {{- end }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.oms.db.userSecretKeyRef }}
+            - name: OMS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.user }}
+            - name: OMS_DB_USER
+              value: {{ .Values.oms.db.user }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                {{- if .Values.oms.db.passwdSecretKeyRef }}
+            - name: OMS_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.passwd }}
+            - name: OMS_DB_PASS
+              value: {{ .Values.oms.db.passwd }}
+                {{- end }}
+                {{- if .Values.oms.db.connectTimeout }}
+            - name: OMS_DB_CONNECT_TIMEOUT
+              value: '{{ .Values.oms.db.connectTimeout }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # log options
+            #
+            {{- if .Values.log }}
+              {{- if .Values.log.level }}
+                {{- if .Values.log.level.scripts }}
+            - name: OMS_LOGLEVEL_SCRIPTS
+              value: {{ .Values.log.level.scripts }}
+                {{- end }}
+              {{- end }}
+              {{- if .Values.log.metadata }}
+                {{- if .Values.log.metadata.tenant }}
+            - name: TENANT
+              value: {{ .Values.log.metadata.tenant }}
+                {{- end }}
+                {{- if .Values.log.metadata.environment }}
+            - name: ENVIRONMENT
+              value: {{ .Values.log.metadata.environment }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # fixed settings
+            #
+            - name: LOG_SHARE
+              value: '/tmp'
+            - name: DB_READY_TIMEOUT
+              value: '300'
+        {{- end }}
+        {{- if .Values.config.enabled }}
+        - name: config
+          imagePullPolicy: {{ .Values.config.image.pullPolicy }}
+          image: "{{ .Values.config.image.repository }}:{{ .Values.config.image.tag }}"
+          resources:
+            {{- toYaml .Values.config.resources | nindent 12 }}
+          env:
+            {{- if .Values.postgres.enabled }}
+            #
+            # database settings, is sub-chart postgres is enabled
+            #
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: ''
+            - name: OMS_DB_HOST
+              value: {{ .Release.Name }}-postgres
+            - name: OMS_DB_PORT
+              value: '5432'
+            {{- else }}
+            #
+            # database settings, if sub-chart postgres is disabled
+            #
+              {{- if .Values.pg }}
+                {{- if .Values.pg.userConnectionSuffix }}
+            - name: OMS_DB_USER_CONNECTION_SUFFIX
+              value: '{{ .Values.pg.userConnectionSuffix }}'
+                {{- end }}
+                {{- if .Values.pg.host }}
+            - name: OMS_DB_HOST
+              value: {{ .Values.pg.host }}
+                {{- end }}
+                {{- if .Values.pg.port }}
+            - name: OMS_DB_PORT
+              value: '{{ .Values.pg.port }}'
+                {{- end }}
+                {{- if .Values.pg.sslMode }}
+            - name: PGSSL_MODE
+              value: '{{ .Values.pg.sslMode }}'
+                {{- end }}
+                {{- if .Values.pg.sslCompression }}
+            - name: PGSSL_COMPRESSION
+              value: '{{ .Values.pg.sslCompression }}'
+                {{- end }}
+                {{- if .Values.pg.sslRootCert }}
+            - name: PGSSL_ROOTCERT
+              value: '{{ .Values.pg.sslRootCert | b64enc }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # common database settings
+            #
+            {{- if .Values.oms }}
+              {{- if .Values.oms.db }}
+                {{- if .Values.oms.db.name }}
+            - name: OMS_DB_NAME
+              value: {{ .Values.oms.db.name }}
+                {{- end }}
+                {{- /* userSecretKeyRef has precedence over user */ -}}
+                {{- if .Values.oms.db.userSecretKeyRef }}
+            - name: OMS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.userSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.user }}
+            - name: OMS_DB_USER
+              value: {{ .Values.oms.db.user }}
+                {{- end }}
+                {{- /* passwdSecretKeyRef has precedence over passwd */ -}}
+                {{- if .Values.oms.db.passwdSecretKeyRef }}
+            - name: OMS_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  {{- toYaml .Values.oms.db.passwdSecretKeyRef | nindent 18 }}
+                {{- else if .Values.oms.db.passwd }}
+            - name: OMS_DB_PASS
+              value: {{ .Values.oms.db.passwd }}
+                {{- end }}
+                {{- if .Values.oms.db.connectTimeout }}
+            - name: OMS_DB_CONNECT_TIMEOUT
+              value: '{{ .Values.oms.db.connectTimeout }}'
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.oms }}
+            #
+            # PlatformConfigProperties
+            #
+              {{- if .Values.oms.archiveOrderMessageLogMinAge }}
+            - name: OMS_ARCHIVE_ORDERMSGLOG_MIN_AGE
+              value: '{{ .Values.oms.archiveOrderMessageLogMinAge }}'
+              {{- end }}
+              {{- if .Values.oms.deleteOrderMessageLogMinAge }}
+            - name: OMS_DELETE_ORDERMSGLOG_MIN_AGE
+              value: '{{ .Values.oms.deleteOrderMessageLogMinAge }}'
+              {{- end }}
+              {{- if .Values.oms.archiveShopCustomerMailMinAge }}
+            - name: OMS_ARCHIVE_SHOPCUSTMAIL_MIN_AGE
+              value: '{{ .Values.oms.archiveShopCustomerMailMinAge }}'
+              {{- end }}
+              {{- if .Values.oms.archiveShopCustomerMailMaxCount }}
+            - name: OMS_ARCHIVE_SHOPCUSTMAIL_MAX_COUNT
+              value: '{{ .Values.oms.archiveShopCustomerMailMaxCount }}'
+              {{- end }}
+              {{- if .Values.oms.deleteShopCustomerMailMinAge }}
+            - name: OMS_DELETE_SHOPCUSTMAIL_MIN_AGE
+              value: '{{ .Values.oms.deleteShopCustomerMailMinAge }}'
+              {{- end }}
+            {{- end }}
+            {{- if .Values.log }}
+            #
+            # log settings
+            #
+              {{- if .Values.log.level }}  
+                {{- if .Values.log.level.scripts }}
+            - name: OMS_LOGLEVEL_SCRIPTS
+              value: {{ .Values.log.level.scripts }}
+                {{- end }}
+              {{- end }}
+              {{- if .Values.log.metadata }}
+                {{- if .Values.log.metadata.tenant }}
+            - name: TENANT
+              value: {{ .Values.log.metadata.tenant }}
+                {{- end }}
+                {{- if .Values.log.metadata.environment }}
+            - name: ENVIRONMENT
+              value: {{ .Values.log.metadata.environment }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            #
+            # control of update steps
+            #
+            - name: SKIP_PROCEDURES
+              {{- if .Values.config.skipProcedures }}
+                {{- if not (kindIs "bool" .Values.config.skipProcedures) }}
+                  {{ fail "config.skipProcedures contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: SKIP_MIGRATION
+              {{- if .Values.config.skipMigration }}
+                {{- if not (kindIs "bool" .Values.config.skipMigration) }}
+                  {{ fail "config.skipMigration contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            - name: SKIP_CONFIG
+              {{- if .Values.config.skipConfig }}
+                {{- if not (kindIs "bool" .Values.config.skipConfig) }}
+                  {{ fail "config.skipConfig contains a non boolean value!" }}
+                {{- end }}
+              value: 'true'
+              {{- else }}
+              value: 'false'
+              {{- end }}
+            {{- if .Values.project }}
+            #
+            # project settings
+            #
+              {{- if .Values.project.envName }}
+            - name: CAAS_ENV_NAME
+              value: {{ .Values.project.envName }}
+              {{- end }}
+            {{- end }}
+            #
+            # execute dbmigrate?
+            # TODO: deprecated, still required for backward compatibilty with versions < 3.3.0.0
+            #
+            - name: OMS_DB_MIGRATION
+            {{- if or .Values.downtime .Release.IsInstall }}
+              value: 'true'
+            {{- else }}
+              value: 'false'
+            {{- end }}
+            #
+            # fixed settings
+            #
+            - name: LOG_SHARE
+              value: '/tmp'
+            - name: DB_READY_TIMEOUT
+              value: '300'
+              
+          # overwrites the default command defined in Dockerfile
+          # db initialization is only executed, if hostname ends with -0, which
+          # only the case for the first server of a stateful set.
+          # TODO: fixed binding on pod ending with "-0" is required for backward compatibility with
+          #   version < 3.3.0.0. Since 3.3.0.0 the file /opt/sql_sha256sum exists and the config
+          #   image is able to decide by himself if db-changes have to be rolled out or not.
+          command:
+            - /bin/sh
+            - "-c"
+            - if [ -f "/opt/sql_sha256sum" ]; then /opt/load_dbmigrate.sh; elif hostname -s | grep -q -- '-0$'; then /opt/load_dbmigrate.sh; fi
+        {{- end }}
+      volumes:
+        - name: app-share-volume
+          persistentVolumeClaim:
+            {{- if .Values.persistence.pvc }}
+            claimName: {{ .Values.persistence.pvc }}
+            {{- else }}
+            claimName: {{ include "iom.fullname" . }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/iom/templates/tests/test-connection.yaml
+++ b/charts/iom/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "iom.fullname" . }}-test-connection"
+  labels:
+    {{- include "iom.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "iom.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/iom/values.yaml
+++ b/charts/iom/values.yaml
@@ -1,0 +1,395 @@
+# Default values for iom.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+downtime: true
+
+image:
+  repository: docker.intershop.de/intershophub/iom
+  # Overrides the image tag whose default is the chart version.
+  tag:
+  pullPolicy: IfNotPresent
+
+# the type of test is fixed. It's the same as used for livenessProbe.
+# As long startupProbe is in progess, no liveness-probes will be executed. This is very
+# important to delay liveness-probe until the initialization (database initialization,
+# database migration, project configuration) is finished.
+# If the liveness-probe finally fails during pod start, it will be killed and caught in
+# an invinite loop of starting and killing.
+# It's essential, that startup-probe will not finally fail during initialization (before
+# Wildfly application server has startet). To do so, you need to configure startupProbe,
+# that
+#   initialDelaySeconds + periodSeconds * failureThreshold
+# is larger than initialization time!
+startupProbe:
+  enabled: true
+  periodSeconds: 10
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  failureThreshold: 60
+
+# the type of test is fixed, as it is an important characteristics of the container.
+# to test liveness, the static HTML page at / of the wildfly application server is tested.
+livenessProbe:
+  enabled: true
+  periodSeconds: 10
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# the type of test is fixed, as it is an important characteristics of the container.
+# to test readiness, the healthckeck service of IOM is tested.
+readinessProbe:
+  enabled: true
+  periodSeconds: 10
+  initialDelaySeconds: 60
+  timeoutSeconds: 8
+  failureThreshold: 1
+  successThreshold: 1
+
+dbaccount:
+  # if enabled, dbaccount will be executed during installation process only, not on upgrade!
+  enabled: false
+  # reinitialize database
+  resetData: false
+  # name of dedicated tablespace
+  tablespace:
+  # options allows to set database options.
+  options: "ENCODING='UTF8' LC_COLLATE='en_US.utf8' LC_CTYPE='en_US.utf8' CONNECTION LIMIT=-1 TEMPLATE=template0"
+  # searchPath extends the search-path for DB objects, e.g.:
+  # searchPath: "testcases"
+  searchPath:
+  image:
+    repository: docker.intershop.de/intershophub/iom-dbaccount
+    tag:        1.4.0
+    pullPolicy: IfNotPresent
+  resources: {}
+  
+config:
+  enabled: false
+  image:
+    repository: 
+    tag:
+    pullPolicy: IfNotPresent
+  resources: {}
+  # allow skipping of initialization steps
+  skipProcedures: false
+  skipMigration:  false
+  skipConfig:     false
+
+# general postgres settings, required to connect to postgres server
+# If postgres sub-chart is enabled, these settings are ignored by all other
+# components, including dbaccount job. Instead of it, the settings defined
+# by the postgres sub-chart will be used.
+pg:
+  host:               postgres-service
+  port:               "5432"
+  userConnectionSuffix:
+  sslMode:            prefer
+  sslCompression:     "0"
+  sslRootCert:
+  #
+  # all following pg parameters are used only by dbaccount. Hence, if
+  # dbaccount.enabled is false, they are ignored completely.
+  #
+  # super-user access to postgres server
+  user:               postgres
+  userSecretKeyRef:   {}
+  passwd:             postgres
+  passwdSecretKeyRef: {}
+  db:                 postgres
+  
+oms:
+  # public URL of IOM
+  # used internally by IOM for link generation.
+  publicUrl:                       https://localhost
+  mailResourcesBaseUrl:            https://localhost/mailimages/customers
+  # Shared secret for JWT creation / validation
+  jwtSecret:                       length_must_be_at_least_32_chars
+  jwtSecretKeyRef:                 {}
+  archiveOrderMessageLogMinAge:    "90"
+  deleteOrderMessageLogMinAge:     "180"
+  archiveShopCustomerMailMinAge:   "1826"
+  archiveShopCustomerMailMaxCount: "10000"
+  deleteShopCustomerMailMinAge:    "2190"
+  # if set to true, secure flag is set to cookies. if secure flag is set, OMT
+  # requires HTTPS to function properly.
+  secureCookiesEnabled:            true
+  # if set to false, no backend-applications will be executed in whole cluster.
+  # this is required in transregional installations of IOM only, where many
+  # local IOM clusters have to work together. In this case, only one of the local
+  # clusters must execute backend-applications (IOM singleton applications).
+  execBackendApps:                 true
+  
+  # IOM database related settings
+  db:
+    name:               oms_db
+    user:               oms_user
+    userSecretKeyRef:   {}
+    passwd:             OmsDB
+    passwdSecretKeyRef: {}
+    # defaults to combination of pg.host and pg.port, which are used by the config-container.
+    # can be overwritten to enable failover of the app-container 
+    hostlist:
+    connectionMonitor:
+      enabled:          false
+      schedule:         "*/1 * * * *"
+    # connect timeout in seconds, a value of 0 indicates to wait indefinitely.
+    # timeout is passed to jdbc and psql connections
+    connectTimeout:     "10"
+    
+  # mail-server related settings
+  # if mailhog sub-chart is enabled, these settings are ignored.
+  # Instead of it, the values of mailhog sub-chart will be used.
+  smtp:
+    host:               mail-service
+    port:               "1025"
+    user:
+    userSecretKeyRef:   {}
+    passwd:
+    passwdSecretKeyRef: {}
+
+# Wildfly related settings
+jboss:
+  # set java options
+  javaOpts: "-XX:+UseContainerSupport -XX:MinRAMPercentage=85 -XX:MaxRAMPercentage=85"
+  # provide the possibility to append java options w/o the need to overwrite javaOpts
+  javaOptsAppend:
+  # set options for wildfly application server, e.g.:
+  # opt: "--debug *:8787"
+  opts:
+  # set pool-size of XA-datasource:
+  xaPoolsizeMin: "50"
+  xaPoolsizeMax: "125"
+  # set size of ActiveMQ client thread pool
+  activemqClientPoolSizeMax: "50"
+  # if set, according value will be used to provide unique values for
+  # jboss.node.name and jboss.tx.node.id. nodePrefix will be extended by the node-number
+  # of the pod within the stateful set.
+  # if left empty, current hostname is used.
+  nodePrefix:
+
+# IOM logging related settings
+log:
+  level:
+    # log-level for scripts can be one of: ERROR, WARN, INFO, DEBUG
+    scripts:       INFO
+    # log-level for following scopes can be one of: FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL
+    console:       WARN
+    iom:           WARN
+    hibernate:     WARN
+    quartz:        WARN
+    activeMQ:      WARN
+    customization: WARN
+  access:
+    enabled:       true
+  # deprecated since iom-helm-charts 1.3.0
+  metadata:
+    tenant:        company-name
+    environment:   system-name
+  # list of operationIDs
+  # if an entry matches the operationID of a REST interface, request and response
+  # of according requests are logged at level DEBUG
+  rest: []
+
+# datadog APM related settings
+datadogApm:
+  # APM library is installed only on host, with name ending on -0.
+  backendOnly: true
+  # Is mapped to DD_APM_ENABLED
+  enabled: false
+  # Host/IP of the agent, that should receive APM traces.
+  # If left empty, the IP of current node is used.
+  # Is mapped to DD_AGENT_HOST
+  traceAgentHost:
+  # Port of the agent, that should receive APM traces.
+  # Is mapped to DD_TRACE_AGENT_PORT
+  traceAgentPort:
+  # Is mapped to DD_TRACE_AGENT_TIMEOUT
+  traceAgentTimeout:
+  # is mapped to DD_LOGS_INJECTION
+  logsInjection: false
+  # is mapped to DD_TRACE_DEBUG
+  debug: false
+  # is mapped to DD_TRACE_STARTUP_LOGS
+  startupLogs: true
+  # is mapped to DD_TAGS
+  tags:
+  # is mapped to DD_SERVICE_MAPPING
+  serviceMapping:
+  # is mapped to DD_WRITER_TYPE
+  # use LoggingWriter print APM traces to console instead of sending them to datadog agent
+  writerType:
+  # is mapped to DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+  partialFlushMinSpan:
+  # is mapped to DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE
+  dbClientSplitByInstance:
+  # is mapped to DD_TRACE_HEALTH_METRICS_ENABLED
+  healthMetricsEnabled: false
+  # is mapped to DD_TRACE_SERVLET_ASYNC_TIMEOUT_ERROR
+  servletAsyncTimeoutError: true
+  # is mapped to DD_TRACE_SAMPLE_RATE
+  sampleRate: '1.0'
+  # is mapped to DD_JMXFETCH_ENABLED
+  jmxFetchEnabled: true
+
+# project related settings
+project:
+  # IOM projects are supporting different settings for different environments
+  # envName defined, which one has to be used.
+  envName:               env-name
+  # controls the import of test data, which are part of the project.
+  importTestData:        false
+  # number of seconds after that the import of test-data has to be finished.
+  # If not, the container will end with an error.
+  importTestDataTimeout: 300
+
+persistence:
+  storageClass: azurefile
+  storageSize: 1Gi
+  # To be used in simple environments (e.g. demos) to persist data on local host.
+  # if set, storageClass will be ignored.
+  hostPath:
+  # To be used in multi-regional installations to persist data in different clusters.
+  # if set, storageClass and hostPath are ignored.
+  pvc:
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # paths are treated as list of prefixes. Any URL matching one of the prefixes will
+  # be forwared to IOM.
+  hosts:
+    - host: iom.example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 1000m
+    memory: 2000Mi
+  requests:
+    cpu: 1000m
+    memory: 2000Mi
+
+imagePullSecrets: []
+nameOverride: 
+fullnameOverride: 
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+postgres:
+  enabled: false
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    storageSize: 2Gi
+    forceReset: false
+
+mailhog:
+  enabled: false
+  probes:
+    enabled: true
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: mailhog-test.poc.intershop.de
+        paths:
+          - path: /
+            pathType: Prefix
+
+    tls: []
+    #  - secretName: wildcard-poc-tls
+    #    hosts:
+    #      - chart-example.local
+
+iom-tests:
+  enabled: false
+
+# internal ingress-nginx controller
+# this ingress-nginx controller cannot be globally used, it is restricted to the namespace
+# There is also a strong problem with the name "ingress-nginx". It contains a '-', which is
+# invalid for names of variables, hence these variables cannot be accessed within templates!
+# As a workaround "nginx" was added. Therefore ingress-nginx is only used to configure the
+# nginx-controller statically. 
+ingress-nginx:
+  rbac:
+    create: true
+    scope: true
+  controller:
+    admissionWebhooks:
+      enabled: false
+    config:
+      use-forwarded-headers: "true"
+      proxy-add-original-uri-header: "true"
+    ingressClass: nginx-iom
+    ingressClassResource:
+      name: nginx-iom
+    extraArgs:
+      # increase verbosity
+      # v: 3
+    replicaCount: 2
+    # watch only for ingress in current namespace
+    scope:
+      enabled: true
+    service:
+      # internal ingress-nginx controller must never be accessed from public network
+      type: "ClusterIP"
+
+# Workaround to overcome the problem with '-' in names of variables.
+# The following variables do not have any impact on the configuration of ingress-nginx (except the enabled flag).
+# They are provided to be used in templates.
+nginx:
+  enabled: false
+  # for very simple (demo-)installations, the internal nginx-controller can be used as public
+  # ingress too, if proxy.enabled is set to false.
+  proxy:
+    enabled: true
+    annotations: {}


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ x] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
[ x] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ x ] Application / infrastructure changes

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Introduction
Welcome to the IOM Helm Charts 2.1.
IOM is delivered as Docker images which are dedicated to run in Kubernetes. Intershop also provides Helm Charts for IOM, which allow to easily operate the system.

## Dependency Version Information
For the best compatibility between IOM Helm charts and IOM, please always use the newest version of IOM Helm charts, regardless of the IOM version you are currently using. To do so, please update IOM Helm charts as often as possible.

| Helm \ IOM | 3.0 | 3.1 | 3.2 | 3.3 | 3.4 | 3.5 | 3.6 | 3.7 | 4.0 | 4.1 |
|-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --|
| 2.1 | 1),2),3),4),5),6),7),8) | 4),6),7),8) | 5),6),7),8) | 6),7),8) | 7),8) | 8) | 9) |   |   | 
| 2.0 | 1),2),3),4),5),6),7),8) | 4),6),7),8) | 5),6),7),8) | 6),7), 8) | 7),8) | 8) | 9) |   |   | x |
| 1.6 | 1),2),3),4),5),6),7),8) | 4),6),7),8) | 5),6),7),8) | 6),7),8) | 7),8) | 8) | 9) |   | x | x |
| 1.5 | 1),2),3),4),5),6),7),8) | 4),6),7),8) | 5),6),7),8) | 6),7),8) | 7),8) | 8) |   | x | x | x |
| 1.4 | 1),2),3),4),5),6),7) | 4),6),7) | 5),6),7) | 6), 7) | 7) |   | x | x | x | x |
| 1.3 | 1),2),3),4),5),6) | 4),6) | 5),6) | 6) |   | x | x | x | x | x |
| 1.2.1 | 1),2),3),4),5) | 4),5) | 5) |   | x | x | x | x | x | x |
| 1.2.0 | 1),2),3),4) | 4) |   | x | x | x | x | x | x | x |
| 1.1.0 | 1) |   | x | x | x | x | x | x | x | x |
| 1.0.0 |  | x | x | x | x | x | x | x | x | x |

x) not supported

1) Defect [IOM-10458](http://support.intershop.com/kb/index.php/Display/IOM-10458) still occurs in this combination
2) Helm parameter for timeout of test-data import does not work in this combination
3) Helm parameter to control creation of access log does not work in this combination
4) Defect [IOM-10362](http://support.intershop.com/kb/index.php/Display/IOM-10362) still occurs in this combination
5) Defect [IOM-10891](http://support.intershop.com/kb/index.php/Display/IOM-10891) still occurs in this combination
6) Helm parameters to control Datadog APM do not work in this combination
7) Helm parameter jboss.nodePrefix does not work in this combination
8) Helm parameters log.rest, config.skip*, oms.db.connectionMonitor.*, oms.db.connectTimeout do not work in this combination.
9) Helm parameter jboss.activemqClientPoolSizeMax does not work in this combination

## Glossary

| Term | Description |
| -- | -- |
| Docker | An OS-level virtualization software. |
| Helm | A package manager for Kubernetes. |
| IOM | The abbreviation for Intershop Order Management |
| Kubernetes | An open-source system for automating deployment, scaling, and management of containerized applications. |

## New Features

<!--
[upgrade mailhog chart to version 5.0](https://dev.azure.com/intershop-com/Products/_workitems/edit/65853)
[Update integrated NGINX to version 4](https://dev.azure.com/intershop-com/Products/_workitems/edit/69692)
[Enable to switch off liveness and readiness probes of mailhog](https://dev.azure.com/intershop-com/Products/_workitems/edit/75987)
[Update to Helm 3.8](https://dev.azure.com/intershop-com/Products/_workitems/edit/75961)
[Add "javaOptsAppend" helm value](https://dev.azure.com/intershop-com/Products/_workitems/edit/75247)
[Update version of dbaccount image](https://dev.azure.com/intershop-com/Products/_workitems/edit/76003)
-->

### Default value of _dbaccount.image.tag_ was updated

The new default value of _dbaccount.image.tag_ is `1.4.0`, which enables the usage of the newest release of the iom-dbaccount image.

### New parameter _jboss.javaOptsAppend_ was Added

The new Helm parameter _jboss.javaOptsAppend_ was added, which allows to define Java options without the need to overwrite the default value provided by _jboss.javaOpts._ This change will reduce migration efforts in future, since users do not have to track changes of default values and re-apply them into their individual settings.

_jboss.javaOptsAppend_ is empty per default.

### Integrated Mailhog was Updated

The Helm Chart of the integrated Malihog sub-chart was updated to version 5.0.6.

### Integrated NGINX was Updated

The Helm chart of the integrated NGINX ingress controller was updated to version 4.0.19.

### IOM Helm templates were Updated

The IOM Helm templates were updated to Helm version 3.8.1.

### Liveness and Readiness Probes of Mailhog can now be disabled

The liveness and readiness probes of Mailhog are producing a lot of messages. It's now possible to disable these probes, which avoids the creation of the messages. Therefore the new Helm parameter _mailhog.probes.enabled_ was added. Its default value is `true`.

## Fixed Defects

| Key | Summary |
| -- | -- |
| 76274 | default memory settings are causing OOM |

## Migration Notes
<!--
[Setting root cert for db is failing](https://dev.azure.com/intershop-com/Products/_workitems/edit/75373)
[90% memory usage is to high and leads to OOM errors](https://dev.azure.com/intershop-com/Products/_workitems/edit/76274)
[Add "javaOptsAppend" helm value](https://dev.azure.com/intershop-com/Products/_workitems/edit/75247)
[Update version of dbaccount image](https://dev.azure.com/intershop-com/Products/_workitems/edit/76003)
-->

### Default value of parameter _dbaccount.image.tag_ has changed

The default value of parameter _dbaccount.image.tag_ has changed from `1.3.0.0` to `1.4.0`. 

### New parameter _jboss.javaOptsAppend__ provided

If you have overwritten _jboss.javaOpts_, you should check if the same result can be reached by using _jboss.javaOptsAppend_ instead. When using _jboss.javaOptsAppend_, the migration efforts will be reduced in the future, since you don't have to track and re-apply any changes made on _jboss.javaOpts_.

### Default value of parameter _jboss.javaOpts_ has changed

The default value of parameter _jboss.javaOpts_ has changed from

    "-XX:+UseContainerSupport -XX:MinRAMPercentage=90 -XX:MaxRAMPercentage=90"

to

    "-XX:+UseContainerSupport -XX:MinRAMPercentage=85 -XX:MaxRAMPercentage=85".

If your installation has overwritten the default value, you should update your individual settings too.

### Format of parameter _pg.sslRootCert_ has changed

Values for parameter _pg.sslRootCert_ have a different format now. Certificates have now to be passed as is, no quoting must be applied. Example:

    pg:
      sslRootCert: |
        -----BEGIN CERTIFICATE-----
        MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ
        RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD
        VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX
        DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y
        ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy
        VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr
        mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr
        IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK
        mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu
        XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy
        dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye
        jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1
        BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3
        DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92
        9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx
        jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0
        Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz
        ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS
        R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
        -----END CERTIFICATE-----

### Default value of _pg.sslRootCert_ has changed

_pg.sslRootCert_ is empty now on default. In older versions of IOM Helm Charts the default value was set to the content of [BaltimoreCyberTrustRoot.crt.pem](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem). If your setup relies on this certificate, you have to set it now in your values file, using the format shown above.

## Known Defects

| Key | Summary |
| -- | -- |
| 69933 | It's not possible to use the internal NGINX in combination with a global NGINX ingress-controller |
| 76294 | internal NGINX ingress-controller cannot use custom ingress-class nginx-iom (it's using class nginx instead) |





