### PR TITLE
Feature/69637 enable http2 protocol by default

### DIFF
--- a/charts/icm-replication/values.yaml
+++ b/charts/icm-replication/values.yaml
@@ -47,7 +47,7 @@ icm-edit:
     webadapter:
       replicaCount: 1
       image:
-        repository: intershophub/icm-webadapter:2.3.0
+        repository: intershophub/icm-webadapter:2.4.0
         secret: dockerhub
     agent:
       replicaCount: 1
@@ -105,7 +105,7 @@ icm-live:
     webadapter:
       replicaCount: 1
       image:
-        repository: intershophub/icm-webadapter:2.3.0
+        repository: intershophub/icm-webadapter:2.4.0
         secret: dockerhub
     agent:
       replicaCount: 1

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -75,6 +75,10 @@ spec:
           env:
           - name: ICM_ICMSERVLETURLS
             value: "cs.url.0=http://{{ .Release.Name }}-{{ .Values.appServerConnection.serviceName }}:{{ .Values.appServerConnection.port }}/servlet/ConfigurationServlet"
+          {{- if .Values.webadapter.useHTTP2 }}
+          - name: USEHTTP2
+            value: true
+          {{- end }}
           {{- if .Values.environment }}
             {{- range $key, $value := .Values.environment }}
           - name: {{ $key }}

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -75,8 +75,8 @@ spec:
           env:
           - name: ICM_ICMSERVLETURLS
             value: "cs.url.0=http://{{ .Release.Name }}-{{ .Values.appServerConnection.serviceName }}:{{ .Values.appServerConnection.port }}/servlet/ConfigurationServlet"
-          {{- if .Values.webadapter.useHTTP2 }}
-          - name: USEHTTP2
+          {{- if .Values.webadapter.disableHTTP2 }}
+          - name: ICM_WEBSERVER_DISABLE_HTTP2
             value: true
           {{- end }}
           {{- if .Values.environment }}

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -15,8 +15,8 @@ webadapter:
     pullPolicy: IfNotPresent
     command: |
       /intershop/bin/intershop.sh
-  # set HTTP/2 protocol support
-  useHTTP2: true
+  # disable HTTP/2 protocol support if required
+  disableHTTP2: false
   customHttpdConfig: false
   # provides custom certificates for webadapter
   customSSLCertificates: false

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 webadapter:
   image:
-    repository: intershophub/icm-webadapter:2.3.0
+    repository: intershophub/icm-webadapter:2.4.0
     secret: dockerhub
     pullPolicy: IfNotPresent
     command: |

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -15,6 +15,8 @@ webadapter:
     pullPolicy: IfNotPresent
     command: |
       /intershop/bin/intershop.sh
+  # set HTTP/2 protocol support
+  useHTTP2: true
   customHttpdConfig: false
   # provides custom certificates for webadapter
   customSSLCertificates: false

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -40,7 +40,7 @@ icm-web:
   webadapter:
     replicaCount: 1
     image:
-      repository: intershophub/icm-webadapter:2.3.0
+      repository: intershophub/icm-webadapter:2.4.0
       secret: dockerhub
   agent:
     # in some REST-based environment the webadapteragent isn't mandatory


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[x] Application / infrastructure changes

## What Is the Current Behavior?

Currently HTTP/1.1 is used by the webserver / webadapter.

Issue Number: Closes #69637 (Azure Issue)

## What Is the New Behavior?

HTTP/2 is enabled by default in webadapter version 2.4.0 and can be disabled if required with the `disableHTTP2` configuration value or environment variable `ICM_WEBSERVER_DISABLE_HTTP2` respectively.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No


