### PR TITLE
feat(iom): increased default value of startupProbe.failureTreshold fr…

### DIFF
--- a/charts/iom/README.rst
+++ b/charts/iom/README.rst
@@ -94,6 +94,15 @@ the required number of nodes, the deployment of IOM will fail.
 
 Please check your cluster in advance. If the capacity is not sufficient, please use *podAntiAffinity.mode: preferred* instead.
 
+Default value of *startupProbe.failureTreshold* was changed
+===========================================================
+
+The default value of *startupProbe.failureTreshold* was increased from 60 to 354, which increases the default timeout for database
+initialization and migration from 11 minutes to one hour. If the new default value is not matching the requirements, you have to set
+the right value within the values file.
+
+See also `Helm parameters of IOM <docs/ParametersIOM.rst>`_.
+
 -------------
 Fixed Defects
 -------------

--- a/charts/iom/docs/ExampleDemo.rst
+++ b/charts/iom/docs/ExampleDemo.rst
@@ -64,6 +64,12 @@ The values file contains minimal settings only, except *dbaccount.resetData*, wh
     repository: "docker.intershop.de/intershophub/iom"
     tag: "4.0.0"
 
+  # define a timeout for startupProbe, that is matching the requirements of the current
+  # IOM installation. In combination with the default values, this configuration results
+  # in a timeout value of 11 minutes for the initialization and migration of the database.
+  startupProbe:
+    failureThreshold: 60
+    
   # remove resource binding for cpu. This makes the system significantly
   # faster, especially the startup.
   resources:

--- a/charts/iom/docs/ExampleProd.rst
+++ b/charts/iom/docs/ExampleProd.rst
@@ -43,7 +43,7 @@ Requirements and characteristics are numbered again. You will find these numbers
 * Shared file system of IOM located on externally provided resources.
 * Usage of an external NGINX Ingress controller.
 * The system should be able to be upgraded without downtime.
-* Time for initialization, migration, and configuration has to be increased due to the specific characteristics of the project.
+* Time for initialization, migration, and configuration has to be adapted due to the specific characteristics of the project.
 
 Values File
 ===========
@@ -69,7 +69,7 @@ Of course, this values file cannot be copied as it is. It references external re
     repository: "project-repository/iom-project"
     tag: "1.0.0"
 
-  # increase the time that is available for initialization, migration, and
+  # specify the time that is available for initialization, migration, and
   # configuration (requirement #8)
   startupProbe:
     failureThreshold: 120
@@ -156,7 +156,7 @@ Create a file *values.yaml* and fill it with the content listed above in `Values
   kubectl create namespace mycompany-iom
  
   # install IOM into namespace mycompany-iom
-  helm install ci intershop/iom --values=values.yaml --namespace mycompany-iom --timeout 20m0s --wait		
+  helm install ci intershop/iom --values=values.yaml --namespace mycompany-iom --timeout 30m0s --wait		
 
 This installation process will now take some minutes to finish. In the meantime, the progress of the installation process can be observed within a second terminal window. Using *kubectl*, you can see the status of every Kubernetes object. For simplicity, the following example shows the status of pods only.
 
@@ -215,7 +215,7 @@ These changes are now rolled out by running the *Helm* upgrade process to the ex
 
 .. code-block: shell
 
-  helm upgrade ci intershop/iom --values=values.yaml --namespace mycompany-iom --timeout 20m0s --wait
+  helm upgrade ci intershop/iom --values=values.yaml --namespace mycompany-iom --timeout 30m0s --wait
 
 The upgrade process will take some minutes before being finished.
 

--- a/charts/iom/docs/ParametersIOM.rst
+++ b/charts/iom/docs/ParametersIOM.rst
@@ -462,18 +462,18 @@ Parameters of IOM Helm Chart
 |                                        |<https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe>`_.          |                                              |
 |                                        |                                                                                               |                                              |
 |                                        |Startup probe was introduced with IOM Helm charts 2.0.0, when IOM config image was removed. All|                                              |
-|                                        |the functionality that was executed by the config image before is in IOM version 4.0.0 and the |                                              |
-|                                        |newer part of the IOM image. The startup probe must now be used to observe all the tasks       |                                              |
-|                                        |(create db account, roll out dump, execute stored procedures, run database migrations, apply   |                                              |
-|                                        |project configuration) that are done before the Wildfly application server is started. The     |                                              |
-|                                        |startup probe must not finally fail before the end of the startup phase, otherwise the pod will|                                              |
-|                                        |be ended and restarted. The startup phase ends when startup probe succeeds. To do so, you need |                                              |
-|                                        |to configure startupProbe in such a way that                                                   |                                              |
+|                                        |the functionality that was executed by the config image before is in IOM version >= 4.0.0 part |                                              |
+|                                        |of the IOM image. The startup probe must now be used to observe all the tasks (create db       |                                              |
+|                                        |account, roll out dump, execute stored procedures, run database migrations, apply project      |                                              |
+|                                        |configuration) that are done before the Wildfly application server is started. The startup     |                                              |
+|                                        |probe must not finally fail before the end of the startup phase, otherwise the pod will be     |                                              |
+|                                        |ended and restarted. The startup phase ends when startup probe succeeds. To do so, you need to |                                              |
+|                                        |configure startupProbe in such a way that                                                      |                                              |
 |                                        |                                                                                               |                                              |
 |                                        |  *initialDelaySeconds + periodSeconds * failureThreshold*                                     |                                              |
 |                                        |                                                                                               |                                              |
 |                                        |is larger than the time needed for the startup phase! The default values provided by IOM Helm  |                                              |
-|                                        |charts provide an 11 minute timeframe for the startup phase: 60s + 10 * 60s = 660s = 11min. If |                                              |
+|                                        |charts provide an 11 minute timeframe for the startup phase: 60s + 10s * 354 = 3600s = 1h. If  |                                              |
 |                                        |your system needs more time for the startup phase, you have to adapt the parameters. It is     |                                              |
 |                                        |recommended to increase *startupProbe.failureThreshold* only and to leave all other parameters |                                              |
 |                                        |unchanged.                                                                                     |                                              |
@@ -490,7 +490,7 @@ Parameters of IOM Helm Chart
 |                                        |                                                                                               |                                              |
 |                                        |* Ignored if *config.enabled* is set to *true* (if an IOM of a version < 4.0.0 is used).       |                                              |
 +----------------------------------------+-----------------------------------------------------------------------------------------------+----------------------------------------------+
-|startupProbe.initialDelaySeconds        |Number of seconds after the container has started before startup probes are initiated. Minimum |60                                            |
+|startupProbe.initialDelaySeconds        |Number of seconds after the container has started before startup probes are initiated. Minimum |354                                           |
 |                                        |value is 0.                                                                                    |                                              |
 |                                        |                                                                                               |                                              |
 |                                        |* Requires IOM 4.0.0 or newer                                                                  |                                              |

--- a/charts/iom/values.yaml
+++ b/charts/iom/values.yaml
@@ -27,7 +27,7 @@ startupProbe:
   periodSeconds: 10
   initialDelaySeconds: 60
   timeoutSeconds: 5
-  failureThreshold: 60
+  failureThreshold: 354
 
 # the type of test is fixed, as it is an important characteristics of the container.
 # to test liveness, the static HTML page at / of the wildfly application server is tested.


### PR DESCRIPTION
…om 60 to 354 (#76871)

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ x ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
[ x ] Docs have been added / updated (for bug fixes / features)
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

Default value of *startupProbe.failureTreshold* was changed from 60 to 354.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ x ] Yes
[ ] No

## Other Information
