### PR TITLE
feat: cluster persistence owner shall be 150 (intershop) (#116)

### DIFF
--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -1,4 +1,3 @@
- {{- if .Values.applicationServer.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -219,4 +218,3 @@ spec:
         {{- end }}
       - name: customizations-volume
         emptyDir: {}
-{{- end }}

--- a/charts/icm-as/templates/as-service.yaml
+++ b/charts/icm-as/templates/as-service.yaml
@@ -1,4 +1,3 @@
- {{- if .Values.applicationServer.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +14,3 @@ spec:
     app: {{ include "icm-as.fullname" . }}
 status:
   loadBalancer: {}
-{{- end -}}

--- a/charts/icm-as/templates/cluster-sites-sc.yaml
+++ b/charts/icm-as/templates/cluster-sites-sc.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.persistence.sites.type "cluster" -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .Values.persistence.sites.cluster.storageClass | quote }}
+provisioner: kubernetes.io/azure-file
+allowVolumeExpansion: true
+mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid={{ .Values.podSecurityContext.runAsUser }}
+  - gid={{ .Values.podSecurityContext.runAsGroup }}
+  - mfsymlinks
+  - cache=strict
+  - actimeo=30
+parameters:
+  skuName: Standard_LRS
+{{- end -}}

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -27,7 +27,7 @@ podLabels: []
 image:
   pullPolicy: IfNotPresent
   # 'appServer' container provides the application / service endpoint
-  repository: intershophub/icm-as:11.0.0
+  repository: intershophub/icm-as:11.0.5
   command: |
     /intershop/bin/intershop.sh
 
@@ -72,6 +72,7 @@ serviceAccount:
 podSecurityContext:
   # intershop user - defined by icm-base-docker image
   runAsUser: 150
+  runAsGroup: 150
 
 testConnection:
   port: 80
@@ -127,7 +128,7 @@ persistence:
     type: local
     existingClaim: <claim name>
     cluster:
-      storageClass: azurefile
+      storageClass: azurefile-intershop
     azurefiles:
       shareName: icm-as-share
       secretName: icm-as-share-secret

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -149,9 +149,6 @@ persistence:
     existingClaim: icm-as-cluster-customData-pvc
     mountPoint: /data
 
-applicationServer:
-  enabled: true
-
 # Probes, all values are optional, below are the defaults
 probes:
   startup: {}

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -76,7 +76,7 @@ persistence:
     type: local
     existingClaim: claimName
     cluster:
-      storageClass: azurefile
+      storageClass: azurefile-intershop
     azurefiles:
       shareName: icm-as-share
       secretName: icm-as-share-secret
@@ -114,6 +114,7 @@ service:
 podSecurityContext:
   # intershop user - defined by icm-base-docker image
   runAsUser: 150
+  runAsGroup: 150
 
 appServerConnection:
   serviceName: icm-as


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

When using cluster as persistence type for pagecache and sites the folders are owned by root. No `chown` can change this. The solution is and own storage class setting the right owner.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #116