### PR TITLE
doc: Include a hint to select a label in pr-template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ Please check if your PR fulfills the following requirements:
 
 [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
 [ ] Docs have been added / updated (for bug fixes / features)
+[ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
 -->
 
 ## PR Type
@@ -21,6 +22,10 @@ Please check the one that applies to this PR using "x".
 [ ] CI-related changes
 [ ] Documentation content changes
 [ ] Application / infrastructure changes
+
+## Release ##
+
+Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.
 
 ## What Is the Current Behavior?
 


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ X ] Documentation content changes
[ ] Application / infrastructure changes

## Other Information

> Can we add a reminder to manually set the major/minor/patch label to the PR template? Like some other "PR checklists" as seen on open source projects