### PR TITLE
feat: support page prefetch

### DIFF
--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -111,5 +111,8 @@ The only mandatory property is `host` to denote the full qualified name for your
 | path     | `/`         |
 | proto    | `https`     |
 | cron     | `0 0 * * *` |
+| stop     | `3600`      |
 
-The value for cron determines the schedule of the prefetch job. You can search the internet for "cron tab syntax" or use [tooling](https://crontab.guru) to come up with a correct value.
+The value for `cron` determines the schedule of the prefetch job. You can search the internet for "cron tab syntax" or use [tooling](https://crontab.guru) to come up with a correct value.
+
+The value for `stop` determines the duration in seconds after the job is forcefully stopped. Forcefully stopping is still considered to be a successful run for container/job.

--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -98,18 +98,18 @@ Example:
 prefetch:
   - host: customer-int.pwa.intershop.de
     path: /b2c/home
-    proto: https
+    protocol: https
     cron: "0 23 * * *"
 ```
 
-Above example configures the prefetch to happen everyday at 11:00 pm. It will request the initial page at https://customer-int.pwa.intershop.de/b2c/home
+The above example configures the prefetch to happen everyday at 11:00 pm. It will request the initial page at https://customer-int.pwa.intershop.de/b2c/home
 
 The only mandatory property is `host` to denote the full qualified name for your site. That host has to be contained in your ingress configuration. All other properties have reasonable defaults.
 
 | Property | Default     |
 | -------- | ----------- |
 | path     | `/`         |
-| proto    | `https`     |
+| protocol | `https`     |
 | cron     | `0 0 * * *` |
 | stop     | `3600`      |
 

--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -3,13 +3,17 @@
 Installs the [Intershop PWA system](https://github.com/intershop/intershop-pwa) in a kubernetes cluster environment.
 
 ## TL;DR
+
 Via command line:
+
 ```bash
 $ helm repo add intershop https://intershop.github.io/helm-charts
 $ helm repo update
 $ helm install my-release intershop/pwa-main
 ```
+
 or via [Flux](https://fluxcd.io) configuration:
+
 ```yaml
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -30,22 +34,32 @@ spec:
     version: 0.4.0
   values:
 ```
+
 ## Upgrading an existing Release to a new Major Version
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
 incompatible breaking change needing manual actions. These actions will be descibed as part of the release documentation available on GitHub.
 
 ## Parameters
+
 ### NGinx
 
-| Name                                      | Description                                   |  Example Value                                          |
-|-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `cache.multiChannel`                      | Multi channel/site configuration object       | `.+:`<br>`channel: default`                             |
-| `cache.cacheIgnoreParams`                 | NGinx ignore query parameters during caching  | `params:`<br>`- utm_source`<br>`- utm_campaign`         |
-| `cache.extraEnvVars`                      | Extra environment variables to be set         | `extraEnvVars:`<br>`- name: FOO`<br>  ` value: BAR`     |
+| Name                      | Description                                                | Example Value                                           |
+| ------------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| `cache.multiChannel`      | Multi channel/site configuration object                    | `.+:`<br>`channel: default`                             |
+| `cache.cacheIgnoreParams` | NGinx ignore query parameters during caching               | `params:`<br>`- utm_source`<br>`- utm_campaign`         |
+| `cache.extraEnvVars`      | Extra environment variables to be set                      | `extraEnvVars:`<br>`- name: FOO`<br> ` value: BAR`      |
+| `cache.prefetch`          | Specify settings for the prefetch job that heats up caches | `prefetch:`<br>`- host: example.com`<br> ` path: /home` |
 
 Both `cacheIgnoreParams` and `multiChannel` parameters take precedence over any `extraEnvVars` value containing `MULTI_CHANNEL` or `CACHING_IGNORE_PARAMS` variables
 
+### SSR
+
+| Name                     | Description                              | Example Value |
+| ------------------------ | ---------------------------------------- | ------------- |
+| `hybrid.enabled`         | Enable or disable hybrid mode deployment | `true`        |
+| `hybrid.backend.service` | ICM Web Adapter service name             | `icm-web`     |
+| `hybrid.backend.port`    | ICM Web Adapter service port             | `443`         |
 
 ## Hybrid mode
 
@@ -54,29 +68,48 @@ Installs the [Intershop PWA and ICM system](https://github.com/intershop/intersh
 To configure the PWA Helm chart for that mode you must first set `hybrid.enabled` to `true`. This will activate conditional dependencies to one umbrella chart `icm` that itself depends on `icm-as` and `icm-web`. Both of which require individual configuration. Please refer to their documentation for details on that. In the end you must add each configuration values object to the `values.yaml` file that reflects your deployment.
 
 Example:
+
 ```yaml
 image:
   repository: intershophub/intershop-pwa-ssr
-...
+---
 cache:
   image:
     repository: intershophub/intershop-pwa-nginx
-...
+---
 icm:
   icm-as:
     image:
       repository: intershophub/icm-as
-...
-  icm-web:
-    webadapter:
-      image:
-        repository: intershophub/icm-webadapter
-...
+---
+icm-web:
+  webadapter:
+    image:
+      repository: intershophub/icm-webadapter
 ```
 
-## Parameters
-| Name                                      | Description                                   |  Example Value                                          |
-|-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `hybrid.enabled`                          | Enable or disable hybrid mode deployment      | `true`                                                  |
-| `hybrid.backend.service`                  | ICM Web Adapter service name                  | `icm-web`                                               |
-| `hybrid.backend.port`                     | ICM Web Adapter service port                  | `443`                                                   |
+## NGinx cache prefetch
+
+The prefetch job is implemented as `wget` in recursive spider mode with level limit 0. This means it is following all links it found in the initial requested page. The link to that first page will be created by the given helm chart values. Since one PWA deployment can host several sites you can provide prefetch config values as array items.
+
+Example:
+
+```yaml
+prefetch:
+  - host: customer-int.pwa.intershop.de
+    path: /b2c/home
+    proto: https
+    cron: "0 23 * * *"
+```
+
+Above example configures the prefetch to happen everyday at 11:00 pm. It will request the initial page at https://customer-int.pwa.intershop.de/b2c/home
+
+The only mandatory property is `host` to denote the full qualified name for your site. That host has to be contained in your ingress configuration. All other properties have reasonable defaults.
+
+| Property | Default     |
+| -------- | ----------- |
+| path     | `/`         |
+| proto    | `https`     |
+| cron     | `0 0 * * *` |
+
+The value for cron determines the schedule of the prefetch job. You can search the internet for "cron tab syntax" or use [tooling](https://crontab.guru) to come up with a correct value.

--- a/charts/pwa/templates/_helpers.tpl
+++ b/charts/pwa/templates/_helpers.tpl
@@ -80,13 +80,18 @@ pwa channels configuration
 {{- end -}}
 
 {{/*
+Print jobname of pwa prefetch cron job. Jobname is only allowed to contain 51 chars.
+Usage:
+{{ include "pwa-prefetch.jobname" (dict "host" .host "path" .path "context" $) }}
 */}}
 {{- define "pwa-prefetch.jobname" -}}
-{{- printf "%s-%s-%s" (include  "pwa-main.fullname" .context ) "prefect" (sha1sum .host) -}}
+{{- printf "prefetch-%.43s" (sha1sum (cat .host (default "/" .path))) -}}
 {{- end -}}
 
 {{/*
-*/}}
+Print url of initial page to start crawling
+Usage:
+{{ include "pwa-prefetch.url" (dict "proto" .proto "host" .host "path" .path) }}*/}}
 {{- define "pwa-prefetch.url" -}}
 {{- printf "%s://%s%s" (default "https" .proto) .host (default "/" .path) -}}
 {{- end -}}

--- a/charts/pwa/templates/_helpers.tpl
+++ b/charts/pwa/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Usage:
 {{/*
 Print url of initial page to start crawling
 Usage:
-{{ include "pwa-prefetch.url" (dict "proto" .proto "host" .host "path" .path) }}*/}}
+{{ include "pwa-prefetch.url" (dict "protocol" .protocol "host" .host "path" .path) }}*/}}
 {{- define "pwa-prefetch.url" -}}
-{{- printf "%s://%s%s" (default "https" .proto) .host (default "/" .path) -}}
+{{- printf "%s://%s%s" (default "https" .protocol) .host (default "/" .path) -}}
 {{- end -}}

--- a/charts/pwa/templates/_helpers.tpl
+++ b/charts/pwa/templates/_helpers.tpl
@@ -78,3 +78,15 @@ pwa channels configuration
 {{- define "pwa-channels.name" -}}
 {{- printf "%s-%s" (include  "pwa-main.name" . ) "channels" -}}
 {{- end -}}
+
+{{/*
+*/}}
+{{- define "pwa-prefetch.jobname" -}}
+{{- printf "%s-%s-%s" (include  "pwa-main.fullname" .context ) "prefect" (sha1sum .host) -}}
+{{- end -}}
+
+{{/*
+*/}}
+{{- define "pwa-prefetch.url" -}}
+{{- printf "%s://%s%s" (default "https" .proto) .host (default "/" .path) -}}
+{{- end -}}

--- a/charts/pwa/templates/prefetch-job.yaml
+++ b/charts/pwa/templates/prefetch-job.yaml
@@ -23,6 +23,9 @@ spec:
           - name: prefetch
             image: 31099/wget:alpine-3.16
             imagePullPolicy: Always
+            env:
+            - name: SECS
+              value: {{ default 3600 .stop | quote}}
             args: [ "-T",
               "15",
               "--spider",

--- a/charts/pwa/templates/prefetch-job.yaml
+++ b/charts/pwa/templates/prefetch-job.yaml
@@ -1,0 +1,32 @@
+{{ range .Values.cache.prefetch }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "pwa-prefetch.jobname" (dict "host" .host "context" $) }}
+  labels:
+    app.kubernetes.io/name: {{ include "pwa-main.name" $ }}
+    helm.sh/chart: {{ include "pwa-main.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  schedule: {{ default "0 0 * * *" .cron | quote}}
+  jobTemplate:
+    spec:
+      parallelism: 1
+      completions: 1
+      backoffLimit: 5
+      template:
+        spec:
+          containers:
+          - name: prefetch
+            image: 31099/wget:alpine-3.16
+            imagePullPolicy: Always
+            args: [ "-T",
+              "15",
+              "--spider",
+              "--no-check-certificate",
+              "--recursive",
+              "--level",
+              "0",
+              {{ include "pwa-prefetch.url" . | quote }} ]
+{{- end }}

--- a/charts/pwa/templates/prefetch-job.yaml
+++ b/charts/pwa/templates/prefetch-job.yaml
@@ -26,12 +26,14 @@ spec:
             env:
             - name: SECS
               value: {{ default 3600 .stop | quote}}
-            args: [ "-T",
-              "15",
+            args: [
+              "--timeout=15",
               "--spider",
               "--no-check-certificate",
+              "--retry-connrefused",
+              "--tries=5",
+              "--execute=robots=off",
               "--recursive",
-              "--level",
-              "0",
+              "--level=0",
               {{ include "pwa-prefetch.url" . | quote }} ]
 {{- end }}

--- a/charts/pwa/templates/prefetch-job.yaml
+++ b/charts/pwa/templates/prefetch-job.yaml
@@ -1,8 +1,9 @@
 {{ range .Values.cache.prefetch }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "pwa-prefetch.jobname" (dict "host" .host "context" $) }}
+  name: {{ include "pwa-prefetch.jobname" (dict "host" .host "path" .path "context" $) }}
   labels:
     app.kubernetes.io/name: {{ include "pwa-main.name" $ }}
     helm.sh/chart: {{ include "pwa-main.chart" $ }}
@@ -17,6 +18,7 @@ spec:
       backoffLimit: 5
       template:
         spec:
+          restartPolicy: Never
           containers:
           - name: prefetch
             image: 31099/wget:alpine-3.16

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -157,8 +157,8 @@
                       "type": "string",
                       "title": "The fully qualified hostname of the site"
                     },
-                    "proto": {
-                      "$id": "#/properties/cache/properties/prefetch/properties/proto",
+                    "protocol": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/protocol",
                       "type": "string",
                       "title": "The protocol under which to access the site",
                       "default": "https"

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -174,6 +174,12 @@
                       "type": "string",
                       "title": "The cron job schedule",
                       "default": "0 0 * * *"
+                    },
+                    "stop": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/stop",
+                      "type": "integer",
+                      "title": "The maximum duration (in seconds) of a running prefetch job",
+                      "default": "3600"
                     }
                   }
                 }

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -140,8 +140,45 @@
                     "title": "Extra environment variables to be set on NGINX containers",
                     "description": "Extra environment variables to be set on NGINX containers",
                     "additionalProperties": true
+                },
+                "prefetch": {
+                  "$id": "#/properties/cache/properties/prefetch",
+                  "type": "array",
+                  "title": "Prefetch job settings",
+                  "description": "Specify settings for the prefetch job that heats up caches",
+                  "additionalProperties": true,
+                  "default": [],
+                  "items": {
+                    "type": "object",
+                    "required": ["host"],
+                    "properties": {
+                    "host": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/host",
+                      "type": "string",
+                      "title": "The fully qualified hostname of the site"
+                    },
+                    "proto": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/proto",
+                      "type": "string",
+                      "title": "The protocol under which to access the site",
+                      "default": "https"
+                    },
+                    "path": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/path",
+                      "type": "string",
+                      "title": "The path to the first page that is going to be crawled",
+                      "default": "/"
+                    },
+                    "cron": {
+                      "$id": "#/properties/cache/properties/prefetch/properties/cron",
+                      "type": "string",
+                      "title": "The cron job schedule",
+                      "default": "0 0 * * *"
+                    }
+                  }
                 }
-            }
+              }
+          }
         }
     }
 }

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -186,12 +186,11 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.class: nginx
   hosts:
-    - host: pwa.localdev.intershop.de
+    - host: pwa.example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls:
-    - secretName: localdev.intershop.de
-      hosts:
-        - pwa.localdev.intershop.de
-
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -143,6 +143,16 @@ cache:
   ##      value: "BAR"
   extraEnvVars: []
 
+  ####
+  ## @param prefetch Specify settings for the prefetch job that heats up caches.
+  ## E.g:
+  ##  prefetch:
+  ##  - host: customer-int.pwa.intershop.de
+  ##    path: /b2c/home
+  ##    proto: https
+  ##    cron: "0 23 * * *"
+  prefetch: []
+
   replicaCount: 1
 
   image:
@@ -176,11 +186,12 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.class: nginx
   hosts:
-    - host: pwa.example.local
+    - host: pwa.localdev.intershop.de
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  tls:
+    - secretName: localdev.intershop.de
+      hosts:
+        - pwa.localdev.intershop.de
+

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -149,7 +149,7 @@ cache:
   ##  prefetch:
   ##  - host: customer-int.pwa.intershop.de
   ##    path: /
-  ##    proto: https
+  ##    protocol: https
   ##    stop: 3600
   ##    cron: "0 0 * * *"
   prefetch: []

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -148,9 +148,10 @@ cache:
   ## E.g:
   ##  prefetch:
   ##  - host: customer-int.pwa.intershop.de
-  ##    path: /b2c/home
+  ##    path: /
   ##    proto: https
-  ##    cron: "0 23 * * *"
+  ##    stop: 3600
+  ##    cron: "0 0 * * *"
   prefetch: []
 
   replicaCount: 1


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

Preheat the nginx or other caches of upstream services is not supported. The PWA deployment does not provide the means to automatically crawl pages in a schedule based manner.

## What Is the New Behavior?

Include this in your `values.yaml`:
```yaml
prefetch:
  - host: some.site.com
```
to heat up caches for your deployment behind `https://some.site.com/`

## Does this PR Introduce a Breaking Change?

[ ] Yes
[X] No

## Other Information
