### PR TITLE
feat: support prometheus metrics

### DIFF
--- a/charts/pwa/.bumpversion.cfg
+++ b/charts/pwa/.bumpversion.cfg
@@ -3,6 +3,17 @@ current_version = 0.5.0
 commit = true
 tag = false
 message = Bump pwa chart version: {current_version} → {new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>.*))?
+serialize = 
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+values = 
+	start
+	alpha
+	beta
+	gamma
 
 [bumpversion:file:Chart.yaml]
 search = version: {current_version}

--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -116,3 +116,14 @@ The only mandatory property is `host` to denote the full qualified name for your
 The value for `cron` determines the schedule of the prefetch job. You can search the internet for "cron tab syntax" or use [tooling](https://crontab.guru) to come up with a correct value.
 
 The value for `stop` determines the duration in seconds after the job is forcefully stopped. Forcefully stopping is still considered to be a successful run for container/job.
+
+## Prometheus Metrics
+
+To expose metrics of the SSR and the nginx containers both support the `metrics` configuration via helm chart.
+
+```yaml
+metrics:
+  enabled: true
+```
+
+When enabled the SSR will expose the metrics in the deployment cluster on port 9113 while the nginx exposes its metrics on port 9114 each at the `/metrics` endpoint.

--- a/charts/pwa/templates/deployment.yaml
+++ b/charts/pwa/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "pwa-main.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -40,6 +44,10 @@ spec:
           - name: SSR_HYBRID
             value: "true"
         {{- end }}
+        {{- if .Values.metrics.enabled }}
+          - name: PROMETHEUS
+            value: "true"
+        {{- end }}
         {{- with .Values.environment }}
             {{- toYaml . | nindent 10 }}
         {{- end }}
@@ -47,6 +55,11 @@ spec:
             - name: http
               containerPort: 4200
               protocol: TCP
+          {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 9113
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             {{- if empty .Values.livenessProbe }}
             exec:

--- a/charts/pwa/templates/deployment_cache.yaml
+++ b/charts/pwa/templates/deployment_cache.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "pwa-cache.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.cache.podAnnotations }}
+      annotations:
+      {{- toYaml .Values.cache.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -43,6 +47,10 @@ spec:
             value: "/config/multi-channel.yaml"
           - name: CACHING_IGNORE_PARAMS_SOURCE
             value: "/config/caching-ignore-params.yaml"
+        {{- if .Values.cache.metrics.enabled }}
+          - name: PROMETHEUS
+            value: "true"
+        {{- end }}
         {{- range $key, $obj := .Values.cache.extraEnvVars }}
           - name: {{ $obj.name }}
             value: {{ $obj.value | quote }}
@@ -56,6 +64,11 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.cache.metrics.enabled }}
+            - name: metrics
+              containerPort: 9113
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             {{- if empty .Values.cache.livenessProbe }}
             {{- else }}

--- a/charts/pwa/templates/service.yaml
+++ b/charts/pwa/templates/service.yaml
@@ -10,10 +10,16 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: 4200
+    - name: http
       protocol: TCP
-      name: http
+      port: {{ .Values.service.port }}
+      targetPort: 4200
+  {{- if .Values.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: 9113
+      targetPort: 9113
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "pwa-main.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/pwa/templates/service_cache.yaml
+++ b/charts/pwa/templates/service_cache.yaml
@@ -11,10 +11,16 @@ metadata:
 spec:
   type: {{ .Values.cache.service.type }}
   ports:
-    - port: {{ .Values.cache.service.port }}
-      targetPort: 80
+    - name: http
       protocol: TCP
-      name: http
+      port: {{ .Values.cache.service.port }}
+      targetPort: 80
+  {{- if .Values.cache.metrics.enabled }}
+    - name: metrics
+      protocol: TCP
+      port: 9113
+      targetPort: 9114
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "pwa-cache.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -98,6 +98,19 @@
                 "$id": "#/properties/environment/items"
             }
         },
+        "metrics": {
+          "type": "object",
+          "form": true,
+          "title": "Prometheus metrics details",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus metrics exporter",
+              "description": "Create Prometheus metrics exporter",
+              "form": true
+            }
+          }
+        },
         "cache": {
             "$id": "#/properties/cache",
             "type": "object",
@@ -180,6 +193,19 @@
                       "type": "integer",
                       "title": "The maximum duration (in seconds) of a running prefetch job",
                       "default": "3600"
+                    }
+                  }
+                },
+                "metrics": {
+                  "type": "object",
+                  "form": true,
+                  "title": "Prometheus metrics details",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Create Prometheus metrics exporter",
+                      "description": "Create Prometheus metrics exporter",
+                      "form": true
                     }
                   }
                 }

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -40,6 +40,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+## @param podAnnotations Annotations for SSR pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
 ## @param environment Extra environment variables to be set on SSR containers
 ## E.g:
 ## environment:
@@ -47,6 +51,12 @@ affinity: {}
 ##     value: BAR
 ##
 environment: []
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Expose Prometheus metrics of SSR container
+  ##
+  enabled: false
 
 livenessProbe:
   {}
@@ -153,6 +163,12 @@ cache:
   ##    stop: 3600
   ##    cron: "0 0 * * *"
   prefetch: []
+  ## Prometheus Exporter / Metrics
+  ##
+  metrics:
+    ## @param metrics.enabled Expose Prometheus metrics of NGINX container
+    ##
+    enabled: false
 
   replicaCount: 1
 
@@ -175,6 +191,10 @@ cache:
   tolerations: []
 
   affinity: {}
+  ## @param podAnnotations Annotations for NGINX pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
 
   livenessProbe: {}
 


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

PWA has prometheus metrics endpoint for quite some time now. Still the HELM chart did not contain any means to enable metrics nor did it have means to attach annotations necessary for monitoring solutions.

## What Is the New Behavior?

You can use `podAnnotations` to include annotations necessary for your monitoring solution. As well as having two switches with which metrics can be switched off and on. 

## Does this PR Introduce a Breaking Change?

All new objects are optional. Prometheus metrics are disabled by default.

[ ] Yes
[ X ] No


## Other Information
