### PR TITLE
feat: Graceful termination of icm-as

### DIFF
--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -156,13 +156,6 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | trim | nindent 12 }}
-          lifecycle:
-            preStop:
-              httpGet:
-                port: 7743
-                path: /servlet/Hook/Shutdown
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           volumeMounts:
           {{- if .Values.provideCustomConfig }}
           {{- range $k, $v := .Values.provideCustomConfig }}
@@ -221,6 +214,13 @@ spec:
             failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 3 }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds | default 60 }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds | default 5 }}
+          lifecycle:
+            preStop:
+              httpGet:
+                port: http
+                path: /status/action/shutdown
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       initContainers:
       {{- if eq .Values.persistence.sites.type "local" }}
         # the following container

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -253,7 +253,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       volumes:
       {{- if .Values.provideCustomConfig }}
       {{- range $k, $v := .Values.provideCustomConfig }}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -156,6 +156,11 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | trim | nindent 12 }}
+          lifecycle:
+            preStop:
+              httpGet:
+                port: 7743
+                path: /servlet/Hook/Shutdown
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/charts/icm-as/tests/basic-config-values_test.yaml
+++ b/charts/icm-as/tests/basic-config-values_test.yaml
@@ -112,6 +112,21 @@ tests:
           path: spec.template.metadata.labels.label1
           value: one
 
+  - it: terminationGracePeriodSeconds is changed
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      terminationGracePeriodSeconds: 5
+    template: templates/as-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 5
+
   - it: debug is enabled
     release:
       name: icm-as

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -144,6 +144,10 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 150
+      #spec.template.spec.terminationGracePeriodSeconds
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
       #spec.template.spec.volumes
       - contains:
           path: spec.template.spec.volumes

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -94,13 +94,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 3Gi
-      #spec.template.spec.containers[0].lifecycle
-      - equal:
-          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.port
-          value: 7743
-      - equal:
-          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.path
-          value: /servlet/Hook/Shutdown
       #spec.template.spec.containers[0].volumeMounts
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -124,6 +117,13 @@ tests:
           content:
             mountPath: /intershop/jgroups-share
             name: jgroups-volume
+      #spec.template.spec.containers[0].lifecycle
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.path
+          value: /status/action/shutdown
       #spec.template.spec.<misc>
       - equal:
           path: spec.template.spec.dnsPolicy

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -94,6 +94,13 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 3Gi
+      #spec.template.spec.containers[0].lifecycle
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.port
+          value: 7743
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.path
+          value: /servlet/Hook/Shutdown
       #spec.template.spec.containers[0].volumeMounts
       - contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -212,6 +212,9 @@ probes:
 #    initialDelaySeconds: 0
 #    periodSeconds: 5
 
+# Duration in seconds pod needs to terminate gracefully, value is optional, below is the default
+# terminationGracePeriodSeconds: 30
+
 # Enable Microsoft SQL Server for development and testing purposes.
 # ICM will use jdbc:sqlserver://<release>-mssql:1433;database=<msslq.name>;
 # see values of persistence.mssql-data and persistence.mssql-backup


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

The application server pod termination grace period _cannot_ be modified by the `values.yaml`.
No K8s life cycle hooks are executed.

Issue Number: Closes #74660 (ADO)

## What Is the New Behavior?

The application server pod termination grace period _can_ be modified by the `values.yaml`.
A HTTP request it sent to the application server for the K8s preStop life cycle hook.

## Does this PR Introduce a Breaking Change?

[ ] Yes
[x] No