### PR TITLE
feat (icm): support icm-as servlet container management port (#207)

### DIFF
--- a/charts/icm-as/.bumpversion.cfg
+++ b/charts/icm-as/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = true
 tag = false
 message = Bump icm-as chart version: {current_version} → {new_version}

--- a/charts/icm-as/Chart.yaml
+++ b/charts/icm-as/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: icm-as
 description: Intershop Commerce Management - AppServer
 type: application
-version: 0.7.0
-appVersion: 11.0.11
+version: 0.8.0
+appVersion: 11.0.12-dev1

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -143,9 +143,13 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           ports:
-            # Servlet engine connector port
-            - name: http
+            # Servlet engine service connector port
+            - name: svc
               containerPort: 7743
+              protocol: TCP
+            # Servlet engine management connector port
+            - name: mgnt
+              containerPort: 7744
               protocol: TCP
           {{- if .Values.jvm.debug.enabled }}
             # Java Debug port
@@ -196,7 +200,7 @@ spec:
           startupProbe:
             httpGet:
               path: /status/LivenessProbe
-              port: http
+              port: svc
             # wait 60s then poll every 10s up to a total timeout of 120s
             failureThreshold: {{ .Values.probes.startup.failureThreshold | default 6 }}
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | default 60 }}
@@ -204,7 +208,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /status/LivenessProbe
-              port: http
+              port: svc
             #after startup: poll every 10s up to a total timeout of 30s
             failureThreshold: {{ .Values.probes.liveness.failureThreshold | default 3 }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds | default 0 }}
@@ -212,7 +216,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /status/ReadinessProbe
-              port: http
+              port: svc
             #wait 60s (startup min) then poll every 5s up to a total timeout of 15s
             failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 3 }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds | default 60 }}
@@ -220,7 +224,7 @@ spec:
           lifecycle:
             preStop:
               httpGet:
-                port: http
+                port: svc
                 path: /status/action/shutdown
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/charts/icm-as/templates/as-service.yaml
+++ b/charts/icm-as/templates/as-service.yaml
@@ -7,9 +7,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   ports:
-  - name: "7743"
+  - name: svc
     port: 7743
-    targetPort: 7743
+    targetPort: svc
+  - name: mgnt
+    port: 7744
+    targetPort: mgnt
   selector:
     app: {{ include "icm-as.fullname" . }}
 status:

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -72,8 +72,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
-            name: http
+            name: svc
             containerPort: 7743
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mgnt
+            containerPort: 7744
             protocol: TCP
       - contains:
           path: spec.template.spec.containers[0].ports
@@ -120,7 +126,7 @@ tests:
       #spec.template.spec.containers[0].lifecycle
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.path
           value: /status/action/shutdown
@@ -226,9 +232,15 @@ tests:
       - contains:
           path: spec.ports
           content:
-            name: "7743"
+            name: svc
             port: 7743
-            targetPort: 7743
+            targetPort: svc
+      - contains:
+          path: spec.ports
+          content:
+            name: mgnt
+            port: 7744
+            targetPort: mgnt
       #spec.selector
       - equal:
           path: spec.selector.app

--- a/charts/icm-as/tests/probes-liveness_test.yaml
+++ b/charts/icm-as/tests/probes-liveness_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: /status/LivenessProbe
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 3
@@ -47,7 +47,7 @@ tests:
           value: /status/LivenessProbe
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 6

--- a/charts/icm-as/tests/probes-readiness_test.yaml
+++ b/charts/icm-as/tests/probes-readiness_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: /status/ReadinessProbe
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 3
@@ -47,7 +47,7 @@ tests:
           value: /status/ReadinessProbe
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 6

--- a/charts/icm-as/tests/probes-startup_test.yaml
+++ b/charts/icm-as/tests/probes-startup_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: /status/LivenessProbe
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 6
@@ -47,7 +47,7 @@ tests:
           value: /status/LivenessProbe
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.port
-          value: http
+          value: svc
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 12

--- a/charts/icm-web/.bumpversion.cfg
+++ b/charts/icm-web/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.7.0
 commit = true
 tag = false
 message = Bump icm-web chart version: {current_version} → {new_version}

--- a/charts/icm-web/Chart.yaml
+++ b/charts/icm-web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "11.0.0"
+appVersion: "11.0.12-dev1"
 description: Intershop Commerce Management - Web Adapter and Web Adapter Agent
 name: icm-web
-version: 0.6.0
+version: 0.7.0

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -10,7 +10,7 @@ nodeSelector: {}
 
 webadapter:
   image:
-    repository: intershophub/icm-webadapter:2.4.1
+    repository: intershophub/icm-webadapter:2.4.5
     pullPolicy: IfNotPresent
     command: |
       /intershop/bin/intershop.sh
@@ -160,6 +160,6 @@ podSecurityContext:
 
 appServerConnection:
   serviceName: icm-as
-  port: 7743
+  port: 7744
 
 environment: {}

--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "11.0.9"
+appVersion: "11.0.12-dev1"
 description: Intershop Commerce Management - ICM
 name: icm
-version: 0.8.0
+version: 0.9.0
 # test related annotations
 annotations:
   requestedMemoryQuota: 5700Mi

--- a/charts/icm/requirements.yaml
+++ b/charts/icm/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: icm-as
-    version: 0.7.0
+    version: 0.8.0
     repository: file://../icm-as
   - name: icm-web
-    version: 0.6.0
+    version: 0.7.0
     repository: file://../icm-web

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -2,7 +2,7 @@ icm-as:
 
   image:
   #  repository: intershophub/icm-as
-  #  tag: :11.0.9
+  #  tag: :11.0.12-dev1
   imagePullSecrets:
   - "dockerhub"
   replicaCount: 1
@@ -43,7 +43,7 @@ icm-web:
   webadapter:
     replicaCount: 1
     image:
-      repository: intershophub/icm-webadapter:2.4.1
+      repository: intershophub/icm-webadapter:2.4.5
       secret: dockerhub
   agent:
     # in some REST-based environment the webadapteragent isn't mandatory


### PR DESCRIPTION
## PR Type

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## What Is the Current Behavior?

* only the servlet container service port is supported

Issue Number: Closes #207

## What Is the New Behavior?

* icm-as chart: now fully supports the servlet container management port
* icm-web chart: now uses the servlet container management port
* icm chart: versions modified

## Does this PR Introduce a Breaking Change?

[x] Yes
[ ] No

* new port
