### PR TITLE
fix (icm): zip must be installed exactly before usage (#237)

### DIFF
--- a/charts/icm/templates/test-job.yaml
+++ b/charts/icm/templates/test-job.yaml
@@ -114,33 +114,6 @@ spec:
         securityContext:
           runAsUser: 0
       {{- end }}
-      - name: create-relevant-folders
-        image: busybox:1.31
-        command:
-          - "/bin/sh"
-          - "-c"
-          - |
-            set -x
-            apt-get update
-            apt-get install -y zip
-
-            mkdir -p ${HELM_DIRECTORY}/result
-            chown -R 150:150 ${HELM_DIRECTORY}/result
-            chmod 777 ${HELM_DIRECTORY}/result
-
-            mkdir ${HELM_DIRECTORY}/pagedumps
-            chown -R 150:150 ${HELM_DIRECTORY}/pagedumps
-            chmod 777 ${HELM_DIRECTORY}/pagedumps
-        env:
-        {{- range $key, $value := .Values.testrunner.environment }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
-        volumeMounts:
-        - name: testdata-volume
-          mountPath: /data
-        securityContext:
-          runAsUser: 0
       - name: init-wait-for-webserver
         image: busybox:1.31
         resources:

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -97,20 +97,43 @@ testrunner:
   image:
     repository: "${ICM_TEST_IMAGE}"
     command: |
-      sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee -a ${RESULT_DIRECTORY}/istestrunner_log.txt
-      PROCESS_ERROR_LEVEL=$?
-      TEST_EXECUTION_RESULT_STATUS="failed"
-      if [ "${PROCESS_ERROR_LEVEL}" -eq 0 ];
-      then
-        zip -r ${RESULT_DIRECTORY}/pagedumps.zip ${HELM_DIRECTORY}/pagedumps
-        rm -Rf ${HELM_DIRECTORY}/pagedumps
-        TEST_EXECUTION_RESULT_STATUS="success"
-      else
-        top -b -n 1 > ${RESULT_DIRECTORY}/top.txt
-      fi
-      echo "result: ${TEST_EXECUTION_RESULT_STATUS}" > ${RESULT_DIRECTORY}/finished.yml
-      echo "result-datetime: $(date)" >> ${RESULT_DIRECTORY}/finished.yml
-      exit $PROCESS_ERROR_LEVEL
+      set -x
+      mkdir -p ${HELM_DIRECTORY}/result
+      chown -R 150:150 ${HELM_DIRECTORY}/result
+      chmod 777 ${HELM_DIRECTORY}/result
+
+      mkdir ${HELM_DIRECTORY}/pagedumps
+      chown -R 150:150 ${HELM_DIRECTORY}/pagedumps
+      chmod 777 ${HELM_DIRECTORY}/pagedumps
+
+      # be able to zip pagedumps folder
+      apt-get -qq update
+      apt-get -qq install -y zip
+
+      # workaround to keep java in the path
+      export ROOTPATH=$PATH
+
+      # startup
+      su ${SERVER_DIRECTORY_USER} <<'EOF'
+        set -x
+        export PATH=$ROOTPATH
+        sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee -a ${RESULT_DIRECTORY}/istestrunner_log.txt
+        PROCESS_ERROR_LEVEL=$?
+        TEST_EXECUTION_RESULT_STATUS="failed"
+        if [ "${PROCESS_ERROR_LEVEL}" -eq 0 ];
+        then
+          zip -qr ${RESULT_DIRECTORY}/pagedumps.zip ${HELM_DIRECTORY}/pagedumps
+          rm -Rf ${HELM_DIRECTORY}/pagedumps
+          TEST_EXECUTION_RESULT_STATUS="success"
+        else
+          top -b -n 1 > ${RESULT_DIRECTORY}/top.txt
+        fi
+        echo "result: ${TEST_EXECUTION_RESULT_STATUS}" > ${RESULT_DIRECTORY}/finished.yml
+        echo "result-datetime: $(date)" >> ${RESULT_DIRECTORY}/finished.yml
+        exit $PROCESS_ERROR_LEVEL
+      EOF
+  podSecurityContext:
+    runAsUser: 0
   environment:
     CARTRIDGE_LIST: "app_bo_test"
 


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix


## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

pagedump zip is not working
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #237

## What Is the New Behavior?

zipping works

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

