### PR TITLE
feat (icm): enable emptyDir for pagecache volume (#176)

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -72,6 +72,8 @@ spec:
         {{- else if eq .Values.persistence.pagecache.type "nfs" }}
         persistentVolumeClaim:
           claimName: "{{ template "icm-web.fullname" . }}-nfs-pagecache-pvc"
+        {{- else if eq .Values.persistence.pagecache.type "emptyDir" }}
+        emptyDir: {}
         {{- else if eq .Values.persistence.pagecache.type "cluster" }}
         persistentVolumeClaim:
           claimName: "{{ template "icm-web.fullname" . }}-cluster-pagecache-pvc"

--- a/charts/icm-web/templates/waa-deployment.yaml
+++ b/charts/icm-web/templates/waa-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         {{- else if eq .Values.persistence.pagecache.type "nfs" }}
         persistentVolumeClaim:
           claimName: "{{ template "icm-web.fullname" . }}-nfs-pagecache-pvc"
+        {{- else if eq .Values.persistence.pagecache.type "emptyDir" }}
+        emptyDir: {}
         {{- else if eq .Values.persistence.pagecache.type "cluster" }}
         persistentVolumeClaim:
           claimName: "{{ template "icm-web.fullname" . }}-cluster-pagecache-pvc"

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -91,8 +91,8 @@ imagePullSecrets:
 persistence:
   pagecache:
     size: 1Gi
-    # type cluster | nfs | azurefiles | existingClaim | local
-    type: local
+    # type cluster | nfs | azurefiles | existingClaim | local | emptyDir
+    type: emptyDir
     existingClaim: claimName
     cluster:
       storageClass:

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -77,8 +77,7 @@ icm-web:
     httpsPort: 8443
   persistence:
     pagecache:
-      size: 1Gi
-      type: cluster
+      type: emptyDir
     customdata:
       enabled: true
       existingClaim: icm-nfs

--- a/charts/icm/values-test-local.yaml
+++ b/charts/icm/values-test-local.yaml
@@ -36,10 +36,7 @@ icm-web:
   nodeSelector: null
   persistence:
     pagecache:
-      size: 1Gi
-      type: local
-      local:
-        path: /run/desktop/mnt/host/d/tmp/pv/pagecache
+      type: emptyDir
     customdata:
       enabled: false
 


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

there is no emptyDir option for pagecache
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #176

## What Is the New Behavior?

emptyDir is possible for pagecache

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

