### PR TITLE
feat (icm): enable log output to volume mount (#249)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/**
 **/tests/__snapshot__
 **/tests/__results__
 values-iste_linux.yaml
+values-test-local.yaml

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -70,6 +70,10 @@ spec:
         - name: icm-as-server
           image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.customCommand }}
+          command:
+            {{- toYaml .Values.customCommand | trim | nindent 10 }}
+          {{- end }}
           env:
           - name: IS_DBPREPARE
             value: "false"

--- a/charts/icm-as/tests/custom-command_test.yaml
+++ b/charts/icm-as/tests/custom-command_test.yaml
@@ -1,0 +1,44 @@
+suite: tests correctness of customCommand
+templates:
+  - templates/as-deployment.yaml
+tests:
+  - it: customComamnd is not provided
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/as-deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+
+  - it: customComamnd is empty
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      customComamnd: []
+    template: templates/as-deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+
+  - it: customComamnd is provided
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+      # use a separate values-yaml because setting array values directly does not work
+      - values/customCommand.yaml
+    template: templates/as-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["/bin/sh","-c","/custom-dir/custom-script.sh"]

--- a/charts/icm/README.md
+++ b/charts/icm/README.md
@@ -50,8 +50,6 @@ This helm chart also allows you to execute intershop htmlunit tests via a testru
 For the local test execution there are already preconfigured values-files orchestrated by a bash script.
 Follow these steps to execute a test:
 
-1. add a "intershop-license" k8s secret with a valid intershop license
-2. adjust the `start-test-local_vars.sh` to your needs (which docker image to test, which testsuite)
-3. in `values-test-local.yaml` set sites-, pagecache-, testdata-dir to the ones from your system, same lasts for mssql-data and -backup
-4. also adjust the imagePullSecrets for icm-as and the testrunner here `values-test-local.yaml` to be able/authorized to download the docker image
-4. Run: `./start-test-local.sh`
+1. add a "intershop-license" k8s secret with a valid intershop license (e.g. `kubectl create secret generic intershop-license --from-file=license.xml`)
+2. add k8s secrets for icm-web and icm-as (e.g. `kubectl create secret docker-registry dockerhub --docker-username=<your username> --docker-password=<your password> --docker-email=<your email>`)
+3. run: `./start-test-local.sh` and follow the instructions

--- a/charts/icm/start-test-local.sh
+++ b/charts/icm/start-test-local.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
-set -xeu pipefail
+set -eu pipefail
 
 set -o allexport
 source start-test-local_vars.sh
+read -e -p 'Helm chart name: ' -i 'icm-11-test' HELM_CHART_NAME
+read -e -p 'Testsuite: ' -i 'tests.remote.com.intershop.cms.suite.PageListingTestSuite' TESTSUITE
+read -e -p 'Test image: ' -i 'icmbuild.azurecr.io/intershop/icm-as-test:11.0.13-SNAPSHOT' ICM_TEST_IMAGE
+read -e -p 'Base path of your local folder mount: ' -i '/run/desktop/mnt/host/d/tmp/pv' LOCAL_MOUNT_BASE
+read -e -p 'The pull secret for the icm-as+testrunner image (e.g. dockerhub or icmbuildsnapshot): ' -i 'dockerhub' ICM_AS_PULL_SECRET
+read -e -p 'The pull secret for the icm-wa+waa image: ' -i 'dockerhub' ICM_WEB_PULL_SECRET
 set +o allexport
 
 # puts envs into a comma separated list with dollar signs
@@ -12,5 +18,7 @@ env_list=$(env | cut -d '=' -f 1 | sed 's/^PATH$//' | sed 's/^/\$/;s/$/,/' | tr 
 # now only env variables are replaced in values template
 envsubst "${env_list}" < ./values-iste_linux.tmpl | tee values-iste_linux.yaml
 
+envsubst "${env_list}" < ./values-test-local.tmpl | tee values-test-local.yaml
+
 helm dependency update .
-helm upgrade --install ${HELM_DRY_RUN}${HELM_JOB_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml
+helm upgrade --install ${HELM_DRY_RUN}${HELM_CHART_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml

--- a/charts/icm/start-test-local_vars.sh
+++ b/charts/icm/start-test-local_vars.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 HELM_DRY_RUN=""
-HELM_JOB_NAME="icm-11-test"
 
 SERVER_DIRECTORY="not_used"
 CONFIG_DIRECTORY="/data/testplans/1/testsuites/1/workspace/helm/iste-icm-11/config"
@@ -9,11 +8,6 @@ HELM_DIRECTORY="/data/testplans/1/testsuites/1/workspace/helm/iste-icm-11"
 WORKSPACE_DIRECTORY="/data/testplans/1/testsuites/1/workspace"
 
 SERVER_DOCKER_IMAGE="unknown"
-TESTSUITE="tests.remote.com.intershop.cms.suite.ComponentTemplateGeneralTestSuite"
-#TESTSUITE="tests.remote.com.intershop.seo.suite.Seo01TestSuite"
-#TESTSUITE="tests.remote.com.intershop.productcatalog.suite.Product124TestSuite"
-#TESTSUITE="tests.remote.com.intershop.organization.suite.Organization02TestSuite"
-ICM_TEST_IMAGE="icmbuild.azurecr.io/intershop/icm-as-test:82631.6851613872-SNAPSHOT"
 
 TESTRUNNER_DIRECTORY="/intershop/testrunner"
 NODENAME="true"

--- a/charts/icm/tests/default-values-test_test.yaml
+++ b/charts/icm/tests/default-values-test_test.yaml
@@ -84,13 +84,13 @@ tests:
       #spec.template.spec.containers[0].resources
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 1000m
+          value: 800m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 2Gi
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 1000m
+          value: 800m
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 2Gi

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -9,6 +9,20 @@ icm-as:
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
   image:
     repository: "${ICM_TEST_IMAGE}"
+  customCommand:
+    - "/bin/sh"
+    - "-c"
+    - |
+      # workaround to keep java in the path
+      export ROOTPATH=$PATH
+
+      su ${SERVER_DIRECTORY_USER} <<'EOF'
+        export PATH=$ROOTPATH
+        timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+        sh /intershop/bin/intershop.sh appserver  2>&1 | tee outfile $HELM_DIRECTORY/server-logs/as${timestamp}.log
+      EOF
+  podSecurityContext:
+    runAsUser: 0
   copySitesDir:
    enabled: true
    fromDir: ${WORKSPACE_DIRECTORY}/../../../sites
@@ -67,11 +81,27 @@ icm-web:
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     image:
       repository: "${ICM_WEBSERVER_IMAGE}"
+      command: |
+        mkdir -p $HELM_DIRECTORY/server-logs
+        chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs
+        timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+        su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/intershop.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs/wa${timestamp}.log"
   agent:
     image:
       repository: "${ICM_WEBADAPTER_AGENT_IMAGE}"
+      command: |
+        mkdir -p $HELM_DIRECTORY/server-logs
+        chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs
+        timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+        su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/start-waa.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs/waa${timestamp}.log"
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
   environment:
     HELM_DIRECTORY: "${HELM_DIRECTORY}"
+    SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
+    SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
   service:
     httpPort: 8080
     httpsPort: 8443
@@ -158,10 +188,10 @@ testrunner:
 
   resources:
     requests:
-      cpu: 700m
+      cpu: 800m
       memory: 2Gi
     limits:
-      cpu: 700m
+      cpu: 800m
       memory: 2Gi
   initContainer:
     resources:

--- a/charts/icm/values-test-local.tmpl
+++ b/charts/icm/values-test-local.tmpl
@@ -1,7 +1,7 @@
 icm-as:
   nodeSelector: null
   imagePullSecrets:
-  - "icmbuildsnapshot"
+  - "${ICM_AS_PULL_SECRET}"
   license:
     secret:
       name: intershop-license
@@ -10,10 +10,10 @@ icm-as:
       size: 1Gi
       type: local
       local:
-        path: /run/desktop/mnt/host/d/tmp/pv/sites
+        path: ${LOCAL_MOUNT_BASE}/sites
     customdata:
       enabled: true
-      existingClaim: icm-11-test-local-testdata-pvc
+      existingClaim: ${HELM_CHART_NAME}-local-testdata-pvc
       mountPoint: /data
   datadog:
     enabled: false
@@ -25,20 +25,24 @@ icm-as:
         size: 1Gi
         type: local
         local:
-          path: /run/desktop/mnt/host/d/tmp/pv/mssql/data
+          path: ${LOCAL_MOUNT_BASE}/mssql/data
       backup:
         size: 1Gi
         type: local
         local:
-          path: /run/desktop/mnt/host/d/tmp/pv/mssql/backup
+          path: ${LOCAL_MOUNT_BASE}/mssql/backup
 
 icm-web:
   nodeSelector: null
+  imagePullSecrets:
+  - "${ICM_WEB_PULL_SECRET}"
   persistence:
     pagecache:
       type: emptyDir
     customdata:
-      enabled: false
+      enabled: true
+      existingClaim: ${HELM_CHART_NAME}-local-testdata-pvc
+      mountPoint: /data
 
 mail:
   nodeSelector: null
@@ -46,12 +50,12 @@ mail:
 testrunner:
   nodeSelector: null
   imagePullSecrets:
-  - "icmbuildsnapshot"
+  - "${ICM_AS_PULL_SECRET}"
   persistence:
     testdata:
       size: 1Gi
       type: local
       local:
-        dir: /run/desktop/mnt/host/d/tmp/pv/testdata
+        dir: ${LOCAL_MOUNT_BASE}/testdata
   datadog:
     enabled: false


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Feature

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

* There are no logs of icm-as, icm-wa and icm-waa stored to file system (local or nfs) during test execution.
* `./start-test-local.sh` is to complex to start

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #249

## What Is the New Behavior?

* Logs are stored in filesystem during testexecution
* `./start-test-local.sh` is simplified

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No
