### PR TITLE
feat (icm): allow http access since redirect is not working (#256)

### DIFF
--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -57,6 +57,9 @@ icm-as:
 
     # Disable Mailhog for now (#82978)
     MAIL_SMTP_MAILHOG_ENABLED: "false"
+
+    # so http acceses are still allowed (necessary to make test and environment not to complicated)
+    SECUREACCESSONLY: "false"
   persistence:
     sites:
       size: 1Gi


### PR DESCRIPTION

## PR Type

[x] Feature

## Release ##

## What Is the Current Behavior?

http access during test execution is not allowed but needed since redirect is not working

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #256

## What Is the New Behavior?

http access is allowed

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] No
