### PR TITLE
fix (icm): remove last timezone tag (#276)

### DIFF
--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -39,8 +39,6 @@ icm-as:
     jdbcUser: "${DATABASE_USER}"
     jdbcPassword: "${DATABASE_USER}"
   environment:
-    TZ: Europe/Berlin
-
     CARTRIDGE_LIST: "ft_e2e_test"
 
     SERVER_DIRECTORY: "${SERVER_DIRECTORY}"


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[x] Bugfix

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

Still there is a timezone set
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #276

## What Is the New Behavior?

There is no timezone set and icm-as uses UTC

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

