### PR TITLE
feat(icm): enable operation without WA (#85748)

### DIFF
--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -37,9 +37,6 @@ spec:
       annotations:
       {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       {{- end }}
-      {{- if .Values.podBinding.enabled }}
-      aadpodidbinding: {{ .Values.podBinding.binding }}
-      {{- end }}
       labels:
         app: icm-as
         release: {{ include "icm-as.fullname" . }}
@@ -54,6 +51,9 @@ spec:
         {{- end }}
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.podBinding.enabled }}
+        aadpodidbinding: {{ .Values.podBinding.binding }}
         {{- end }}
     spec:
       {{- if .Values.nodeSelector}}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -140,6 +140,10 @@ spec:
           - name: INTERSHOP_JDBC_PASSWORD
             value: "{{ .Values.database.jdbcPassword }}"
           {{- end }}
+          {{- if .Values.webLayer.enabled }}
+          - name: INTERSHOP_WEBADAPTER_ENABLED
+            value: "false"
+          {{- end }}
           {{- include "icm-as.featuredJVMArguments" . | nindent 10 }}
           {{- include "icm-as.additionalJVMArguments" . | nindent 10 }}
           {{- range $key, $value := .Values.environment }}
@@ -200,6 +204,10 @@ spec:
               readOnly: true
               subPath: replication-clusters.xml
           {{- end }}
+          {{- end }}
+          {{- if .Values.sslCertificateRetrieval.enabled }}
+            - mountPath: /mnt/secrets
+              name: secrets-store-inline
           {{- end }}
           startupProbe:
             httpGet:
@@ -366,3 +374,11 @@ spec:
         {{- end }}
       - name: customizations-volume
         emptyDir: {}
+        {{- if .Values.sslCertificateRetrieval.enabled }}
+      - name: secrets-store-inline
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ include "icm-as.fullname" . }}-cert
+        {{- end }}

--- a/charts/icm-as/templates/ingress.yaml
+++ b/charts/icm-as/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "icm-as.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name:  {{ $fullName }}
+    helm.sh/chart: {{ include "icm-as.chart" . }}
+    app.kubernetes.io/instance:  {{ $fullName }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host  $http_host;
+      proxy_set_header X-Forwarded-Port  $server_port;
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend: 
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: svc
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/icm-as/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-as/templates/ssl-certificate-spc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.sslCertificateRetrieval.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "icm-as.fullname" . }}-cert
+spec:
+  provider: azure
+  secretObjects:
+  - secretName:  {{ .Values.sslCertificateRetrieval.secretName | default (printf "%s-cert" (include "icm-as.fullname" .)) }}
+    type: kubernetes.io/tls
+    data:
+    - objectName: "{{ .Values.sslCertificateRetrieval.keyvault.certificateName }}"
+      key: tls.key
+    - objectName: "{{ .Values.sslCertificateRetrieval.keyvault.certificateName }}"
+      key: tls.crt
+  parameters:
+    usePodIdentity: "true"                                                          # [OPTIONAL for Azure] if not provided, will default to "false"
+    tenantId: "{{ .Values.sslCertificateRetrieval.keyvault.tenantId }}"             # the tenant ID of the KeyVault
+    subscriptionId: "{{ .Values.sslCertificateRetrieval.keyvault.subscriptionId }}" # [REQUIRED for version < 0.0.4] the subscription ID of the KeyVault
+    resourceGroup: "{{ .Values.sslCertificateRetrieval.keyvault.resourceGroup }}"   # [REQUIRED for version < 0.0.4] the resource group of the KeyVault
+    keyvaultName: "{{ .Values.sslCertificateRetrieval.keyvault.keyvaultName }}"     # the name of the KeyVault
+    cloudName: ""          # [OPTIONAL available for version > 0.0.4] if not provided, azure environment will default to AzurePublicCloud
+    cloudEnvFileName: ""   # [OPTIONAL available for version > 0.0.7] use to define path to file for populating azure environment
+    objects:  |
+      array:
+        - |
+          objectName: {{ .Values.sslCertificateRetrieval.keyvault.certificateName }}
+          objectType: secret
+{{- end -}}

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -284,3 +284,34 @@ copySitesDir:
   # resultDir: result folder where a sites.txt is generated to
   # chmodUser: user
   # chmodGroup: group
+
+# configure an ingress here only if you don't use icm-web !
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # Paths are treated as list of prefixes. Any URL matching one of the prefixes will
+  # be forwared to ICM.
+  hosts:
+    - host: <dns-name-of-service>
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+webLayer:
+  enabled: false
+sslCertificateRetrieval:
+    enabled: false
+    # secretName: <explicit-ssl-secret-name>
+    keyvault:
+      tenantId: <tenant-ID-of-the-KeyVault>
+      subscriptionId: <subscription-ID-of-the-KeyVault>
+      resourceGroup: <resource-group-of-the-KeyVault>
+      keyvaultName: <name-of-the-KeyVault>
+      certificateName: <name-of-the-certificate>

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -295,10 +295,10 @@ ingress:
   # Paths are treated as list of prefixes. Any URL matching one of the prefixes will
   # be forwared to ICM.
   hosts:
-    - host: <dns-name-of-service>
-      paths:
-        - path: /
-          pathType: Prefix
+  - host: <dns-name-of-service>
+    paths:
+    - path: /
+      pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -307,11 +307,11 @@ ingress:
 webLayer:
   enabled: false
 sslCertificateRetrieval:
-    enabled: false
-    # secretName: <explicit-ssl-secret-name>
-    keyvault:
-      tenantId: <tenant-ID-of-the-KeyVault>
-      subscriptionId: <subscription-ID-of-the-KeyVault>
-      resourceGroup: <resource-group-of-the-KeyVault>
-      keyvaultName: <name-of-the-KeyVault>
-      certificateName: <name-of-the-certificate>
+  enabled: false
+  # secretName: <explicit-ssl-secret-name>
+  keyvault:
+    tenantId: <tenant-ID-of-the-KeyVault>
+    subscriptionId: <subscription-ID-of-the-KeyVault>
+    resourceGroup: <resource-group-of-the-KeyVault>
+    keyvaultName: <name-of-the-KeyVault>
+    certificateName: <name-of-the-certificate>


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the WebAdapter (configured in the icm-web chart) is required in all deployments. This PR introduces the changes necessary for deployments without the WebAdapter / WebAdapterAgent (and without the icm-web chart in general)

Issue Number: Closes 85748 

## What Is the New Behavior?

- an ingress can be configured within the icm-as chart (disabled by default) which points directly to the svc port of the ApplicationServer
- sslCertificateRetrieval is possible from the icm-as chart (disabled by defautl)
- webLayer section added to the icm-as chart (disabled by default). This section will in the future contain all configuration of previously WebAdapter functionality which has moved to the ApplicationServer (such as caching)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information

A bug was also fixed in the as-deployment.yaml regarding aadpodbinding.
