### PR TITLE
fix (icm): turn off mailhog by default (#291)

### DIFF
--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -77,5 +77,8 @@ icm-web:
       local:
         path: <local pagecache folder>
 
+mailhog:
+  enabled: false
+
 test:
   enabled: false


### PR DESCRIPTION
## PR Type

[x] Bugfix


## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

Mailhog is enabled by default

Issue Number: Closes #291

## What Is the New Behavior?

Mailhog is disabled by default

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[x] No

