### PR TITLE
fix(icm): aadpodidbindong applied as label

### DIFF
--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -120,23 +120,29 @@ resources: {{- toYaml .Values.resources | nindent 2 }}
 {{- end -}}
 
 {{/*
-Pod-annotations and bindings
+Pod-annotations
 */}}
 {{- define "icm-as.podData" -}}
 {{- if .Values.podAnnotations -}}
 annotations: {{- toYaml .Values.podAnnotations | nindent 2 }}
 {{- end }}
-{{- if .Values.podBinding.enabled -}}
-aadpodidbinding: {{ .Values.podBinding.binding }}
-{{- end }}
 {{- end -}}
 
 {{/*
-Pod-label
+Pod-labels
 */}}
 {{- define "icm-as.podLabels" -}}
 {{- with .Values.podLabels }}
 {{- . | toYaml | nindent 0 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+AAD Pod-binding label
+*/}}
+{{- define "icm-as.podBinding" -}}
+{{- if .Values.podBinding.enabled }}
+aadpodidbinding: {{ .Values.podBinding.binding }}
 {{- end }}
 {{- end -}}
 

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -41,8 +41,8 @@ spec:
         {{- if include "icm-as.podLabels" . }}
           {{- include "icm-as.podLabels" . | nindent 8 }}
         {{- end }}
-        {{- if .Values.podBinding.enabled }}
-        aadpodidbinding: {{ .Values.podBinding.binding }}
+        {{- if include "icm-as.podBinding" . }}
+          {{- include "icm-as.podBinding" . | nindent 8 }}
         {{- end }}
     spec:
       {{- if include "icm-as.nodeSelector" . }}


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

[ x ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
[ ] Docs have been added / updated (for bug fixes / features)
[ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build-related changes
[ ] CI-related changes
[ ] Documentation content changes
[ ] Application / infrastructure changes

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

`aadpodidbinding` is applied as both an annotation (which is wrong) and a label (which is correct).

## What Is the New Behavior?

`aadpodidbinding` is applied only as a label.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[ ] Yes
[ x ] No

## Other Information
