### PR TITLE
fix (icm): use ft_e2e_test instead of app_bo_test (#301)

### DIFF
--- a/charts/icm/tests/default-values-test_test.yaml
+++ b/charts/icm/tests/default-values-test_test.yaml
@@ -40,7 +40,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: CARTRIDGE_LIST
-            value: "app_bo_test"
+            value: "ft_e2e_test"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -186,7 +186,7 @@ testrunner:
   podSecurityContext:
     runAsUser: 0
   environment:
-    CARTRIDGE_LIST: "app_bo_test"
+    CARTRIDGE_LIST: "ft_e2e_test"
 
     HELM_DIRECTORY: "${HELM_DIRECTORY}"
     RESULT_DIRECTORY: "${RESULT_DIRECTORY}"


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

Testrunner uses an old test cartridge

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #301

## What Is the New Behavior?

Testrunner uses ft_e2e_test like icm-as too

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

