### PR TITLE
feat (icm): remove local volume hacks (#322)

### DIFF
--- a/charts/icm-as/Chart.yaml
+++ b/charts/icm-as/Chart.yaml
@@ -3,4 +3,4 @@ name: icm-as
 description: Intershop Commerce Management - AppServer
 type: application
 version: 1.1.0
-appVersion: 11.1.3
+appVersion: 11.2.0

--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -4,22 +4,6 @@ Creates init-containers
 */}}
 {{- define "icm-as.initContainers" -}}
 initContainers:
-{{- if eq .Values.persistence.sites.type "local" }}
-# the following container
-# 1) only is active if local storage is enabled
-# 2) applies permission 777 to sites volume
-# 3) makes user/group intershop owner of sites volume
-# !) This is necessary for Windows users with Docker Desktop using WSL[2] backend because:
-#    Docker Desktop with WSL[2] creates folders for local volume mounts assigning the user root and permissions 700
-- name: sites-volume-mount-hack
-  image: busybox
-  command: ["sh", "-c", "chmod 777 /intershop/sites && chown -R 150:150 /intershop/sites"]
-  volumeMounts:
-  - name: sites-volume
-    mountPath: /intershop/sites
-  securityContext:
-    runAsUser: 0
-{{- end }}
 {{- if .Values.copySitesDir.enabled }}
 - name: cp-sites-dir
   image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"

--- a/charts/icm-as/tests/customizations_test.yaml
+++ b/charts/icm-as/tests/customizations_test.yaml
@@ -13,12 +13,8 @@ tests:
       customizations: {}
     template: templates/as-deployment.yaml
     asserts:
-      - contains:
+      - isEmpty:
           path: spec.template.spec.initContainers
-          content:
-            name: sites-volume-mount-hack
-          count: 1
-          any: true
 
   - it: one customization with default pullPolicy
     release:
@@ -31,11 +27,6 @@ tests:
       customizations.responsive.repository: responsive-repo:0.8.15
     template: templates/as-deployment.yaml
     asserts:
-      - contains:
-          path: spec.template.spec.initContainers
-          content:
-            name: sites-volume-mount-hack
-          any: true
       - contains:
           path: spec.template.spec.initContainers
           content:
@@ -60,11 +51,6 @@ tests:
       customizations.solrcloud.pullPolicy: Never
     template: templates/as-deployment.yaml
     asserts:
-      - contains:
-          path: spec.template.spec.initContainers
-          content:
-            name: sites-volume-mount-hack
-          any: true
       - contains:
           path: spec.template.spec.initContainers
           content:

--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "11.1.2"
+appVersion: "11.2.0"
 description: Intershop Commerce Management - ICM
 name: icm
 version: 1.2.0

--- a/charts/icm/start-test-local.sh
+++ b/charts/icm/start-test-local.sh
@@ -6,7 +6,7 @@ set -o allexport
 source start-test-local_vars.sh
 read -e -p 'Helm chart name: ' -i 'icm-11-test' HELM_JOB_NAME
 read -e -p 'Testsuite: ' -i 'tests.remote.com.intershop.cms.suite.PageListingTestSuite' TESTSUITE
-read -e -p 'Test image: ' -i 'icmbuild.azurecr.io/intershop/icm-as-test:11.0.13-SNAPSHOT' ICM_TEST_IMAGE
+read -e -p 'Test image: ' -i 'intershophub/icm-as-test:11.2.0' ICM_TEST_IMAGE
 read -e -p 'Base path of your local folder mount: ' -i '/run/desktop/mnt/host/d/tmp/pv' LOCAL_MOUNT_BASE
 read -e -p 'The pull secret for the icm-as+testrunner image (e.g. dockerhub or icmbuildsnapshot): ' -i 'dockerhub' ICM_AS_PULL_SECRET
 read -e -p 'The pull secret for the icm-wa+waa image: ' -i 'dockerhub' ICM_WEB_PULL_SECRET

--- a/charts/icm/templates/test-job.yaml
+++ b/charts/icm/templates/test-job.yaml
@@ -98,22 +98,6 @@ spec:
         - name: testdata-volume
           mountPath: /data
       initContainers:
-      {{- if eq .Values.testrunner.persistence.testdata.type "local" }}
-      # the following container
-      # 1) only is active if local storage is enabled
-      # 2) applies permission 777 to sites volume
-      # 3) makes user/group intershop owner of sites volume
-      # !) This is necessary for Windows users with Docker Desktop using WSL[2] backend because:
-      #    Docker Desktop with WSL[2] creates folders for local volume mounts assigning the user root and permissions 700
-      - name: testdata-volume-mount-hack
-        image: busybox:1.31
-        command: ["sh", "-c", "chmod 777 /data && chown -R 150:150 /data"]
-        volumeMounts:
-        - name: testdata-volume
-          mountPath: /data
-        securityContext:
-          runAsUser: 0
-      {{- end }}
       - name: init-wait-for-webserver
         image: busybox:1.31
         resources:

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -23,6 +23,7 @@ icm-as:
       EOF
   podSecurityContext:
     runAsUser: 0
+    runAsNonRoot: false
   copySitesDir:
    enabled: true
    fromDir: ${WORKSPACE_DIRECTORY}/../../../sites
@@ -102,6 +103,7 @@ icm-web:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+    runAsNonRoot: false
   environment:
     HELM_DIRECTORY: "${HELM_DIRECTORY}"
     SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Feature

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

It's not possible to release because of `runAsNonRoot: true`. The local volume hacks do not work with that. But also seems that we don't need them anymore as there where updates to "DockerDesktop".

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #322

## What Is the New Behavior?

Helmchart could be released

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

