### PR TITLE
feat(icm): allow disabling icm-web from icm chart

### DIFF
--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+enabled: true
 replicaCount: 1
 
 # defined where the application shall run on

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-enabled: true
 replicaCount: 1
 
 # defined where the application shall run on

--- a/charts/icm/requirements.yaml
+++ b/charts/icm/requirements.yaml
@@ -5,6 +5,7 @@ dependencies:
   - name: icm-web
     version: 0.7.5
     repository: file://../icm-web
+    condition: icm-web.enabled
   - name: mailhog
     version: 5.2.0
     repository: https://codecentric.github.io/helm-charts

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -71,6 +71,7 @@ icm-as:
     sourceDatabaseName: <databaseName>
 
 icm-web:
+  enabled: true
   imagePullSecrets:
   - "dockerhub"
   webadapter:


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using the icm umbrella chart, icm-web is always included.

Issue Number: Closes #321 

## What Is the New Behavior?

The icm-web chart can be disabled by setting `icm-web.enabed: false`. The default is `icm-web.enabed: true`.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information
