### PR TITLE
Bump to alpine 3.18

### DIFF
--- a/charts/pwa/templates/prefetch-job.yaml
+++ b/charts/pwa/templates/prefetch-job.yaml
@@ -21,7 +21,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: prefetch
-            image: 31099/wget:alpine-3.16
+            image: 31099/wget:alpine-3.18
             imagePullPolicy: Always
             env:
             - name: SECS


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [X] Application / infrastructure changes

## What Is the Current Behavior?

Prefetch job is running on customized alpine image. Customized in a way that it forcefully exits after a given amount of time. That alpine version is **3.16**.

## What Is the New Behavior?

Alpine version is now **3.18**

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [X] No

## Other Information
[Alpine Release Page](https://www.alpinelinux.org/releases/)