### PR TITLE
fix (icm): imagePullSecret couldn't be read (#340)

### DIFF
--- a/charts/icm-job/templates/icm-job.yaml
+++ b/charts/icm-job/templates/icm-job.yaml
@@ -1,3 +1,11 @@
+{{- define "imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+- name: {{ . | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -274,8 +282,8 @@ spec:
                 operator: In
                 values:
                 - linux
-      {{- if include "icm-as.imagePullSecrets" . }}
-        {{- include "icm-as.imagePullSecrets" . | nindent 6 }}
+      {{- if include "imagePullSecrets" . }}
+        {{- include "imagePullSecrets" . | nindent 6 }}
       {{- end }}
       containers:
       - args:


### PR DESCRIPTION
## PR Type



- [x] Bugfix


## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

icm-job could not deploy

Issue Number: Closes #340

## What Is the New Behavior?

icm-job deploys

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


- [x] No
