### PR TITLE
fix (icm): remove jgroups connection between edit and live (#356)

### DIFF
--- a/charts/icm-replication/values-iste_linux.tmpl
+++ b/charts/icm-replication/values-iste_linux.tmpl
@@ -68,12 +68,6 @@ icm-edit:
         cluster:
           storageClass:
             existingClass: azurefile
-      jgroups:
-        size: 1Gi
-        type: cluster
-        cluster:
-          storageClass:
-            existingClass: azurefile
       customdata:
         enabled: true
         existingClaim: icm-nfs
@@ -183,9 +177,6 @@ icm-live:
         cluster:
           storageClass:
             existingClass: azurefile
-      jgroups:
-        type: existingClaim
-        existingClaim: ${HELM_JOB_NAME}-icm-as-edit-cluster-jgroups-pvc
       customdata:
         enabled: true
         existingClaim: icm-nfs

--- a/charts/icm-replication/values-test-local.tmpl
+++ b/charts/icm-replication/values-test-local.tmpl
@@ -9,11 +9,6 @@ icm-edit:
         type: local
         local:
           path: ${LOCAL_MOUNT_BASE}/sites/edit
-      jgroups:
-        size: 1Gi
-        type: local
-        local:
-          path: ${LOCAL_MOUNT_BASE}/jgroups
       customdata:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc
@@ -44,9 +39,6 @@ icm-live:
         type: local
         local:
           path: ${LOCAL_MOUNT_BASE}/sites/live
-      jgroups:
-        type: existingClaim
-        existingClaim: ${HELM_JOB_NAME}-icm-as-edit-local-jgroups-pvc
       customdata:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

edit and live are connected via jgroups

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #356

## What Is the New Behavior?

edit and live are not connected via jgroups

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
