### PR TITLE
PWA chart improvements

### DIFF
--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -100,6 +100,13 @@ These actions will be described as part of the release documentation available o
 
 ## Parameters
 
+### General
+
+| Name             | Description                    | Example Value                                |
+| ---------------- | ------------------------------ | -------------------------------------------- |
+| `updateStrategy` | The Kubernetes update strategy | `Recreate`<br>`RollingUpdate`&nbsp;(default) |
+
+
 ### NGINX
 
 | Name                      | Description                                                | Example Value                                           |

--- a/charts/pwa/README.md
+++ b/charts/pwa/README.md
@@ -12,91 +12,21 @@ $ helm repo update
 $ helm install my-release intershop/pwa-main
 ```
 
-### Using [Flux](https://fluxcd.io) v1
-
-```yaml
-apiVersion: helm.fluxcd.io/v1
-kind: HelmRelease
-metadata:
-  name: xxx-yyy
-  namespace: xxx-yyy
-
-spec:
-  rollback:
-    enable: true
-    force: true
-  wait: true
-  timeout: 270
-  releaseName: xxx-yyy
-  chart:
-    repository: https://intershop.github.io/helm-charts
-    name: pwa-main
-    version: 0.7.0
-  values:
-```
-
-### Using [Flux](https://fluxcd.io) v2
-
-Here you create a HelmRepository resource in addition to the HelmRelease [(helm-operator-migration Guide from Flux v1 to Flux v2)](https://fluxcd.io/flux/migration/helm-operator-migration/)
-
-```yaml
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: ish-helm-charts
-  namespace: flux-system
-spec:
-  interval: 1m0s
-  url: https://intershop.github.io/helm-charts
-
----
-# PWA HelmRelease
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
-  name: ${namespace}
-  namespace: ${namespace}
-spec:
-  chart:
-    spec:
-      # pwa helm chart, version from https://github.com/intershop/helm-charts
-      chart: pwa-main
-      version: 0.7.0
-      # Source reference to the HelmChart Repo
-      sourceRef:
-        kind: HelmRepository
-        name: ish-helm-charts
-        namespace: flux-system
-  # in case multiple pwa instances will be deployed into the given environment namespace, a postfix has to be added to the
-  # release name (i.e. pwa-$ENVIRONMENT-01 or pwa-$ENVIRONMENT-edit)
-  releaseName: ${namespace}
-  targetNamespace: ${namespace}
-  interval: 1m0s
-  timeout: 5m0s
-   # Helm Values - to be adapted by the dev team
-  values:
-```
-
 ## Release Versions
 
 The following table provides an overview of the different PWA Helm Chart versions and the minimum required PWA version to use it with.
 In addition, the version changes and necessary migration information is provided.
 
-| Chart | PWA    | Changes                                                                                                                                                                                           | Migration Information                                                                                                                                                                                                                        |
-| ----- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chart | PWA    | Changes                                                                                                                                                                                                                    | Migration Information                                                                                                                                                                                                                                         |
+| ----- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.8.0 | 1.0.0  | <ul><li>delay NGINX until PWA SSR is listening</li><li>configurable update strategy</li><li>less verbose prefetch job</li></ul>                                                                                            | <ul><li>configurable `updateStrategy` stays at `RollingUpdate` by default</li></ul>                                                                                                                                                                           |
 | 0.7.0 | 1.0.0  | <ul><li>Re-enabled support for `multi-channel.yaml` and `caching-ignore-params.yaml` source code fallbacks</li><li>Added additional Ingress for domain whitelisting</li><li>Added labels on deployment and pod levels</li> | Removed deprecated configuration options:<ul><li>`upstream.icm`</li><li>`cache.enabled` - was not optional</li><li>`cache.channels`</li></ul>See [Migration to 0.7.0](https://github.com/intershop/helm-charts/blob/main/charts/pwa/docs/migrate-to-0.7.0.md) |
-| 0.6.0 | 1.0.0  | Support for Prometheus metrics                                                                                                                                                                        |                                                                                                                                                                                                                                              |
-| 0.5.0 | 1.0.0  | Added prefetch job that can heat up caches                                                                                                                                                          |                                                                                                                                                                                                                                              |
-| 0.4.0 | 1.0.0  | Support for PWA Hybrid Approach deployment (with ICM 11)                                                                                                                                                  | Requires PWA 3.2.0 for Hybrid Approach support                                                                                                                                                                                                   |
-| 0.3.0 | 1.0.0  | Use new Ingress controller definition                                                                                                                                                             | [Migration to 0.3.0](https://github.com/intershop/helm-charts/blob/main/charts/pwa/docs/migrate-to-0.3.0.md)                                                                                                                                 |
-| 0.2.4 | 0.25.0 | Support for `multiChannel`, `cacheIgnoreParams` and `extraEnvVars` for nginx/cache deployment                                                                                                     | Missing support for `multi-channel.yaml` and `caching-ignore-params.yaml` source code fallbacks                                                                                                                                              |
-| 0.2.3 | 0.25.0 | Legacy Helm Chart 0.2.3 as initial version                                                                                                                                                        |                                                                                                                                                                                                                                              |
-
-### Upgrading an Existing Release to a New Major Version
-
-A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change that requires manual actions.
-These actions will be described as part of the release documentation available on GitHub.
+| 0.6.0 | 1.0.0  | Support for Prometheus metrics                                                                                                                                                                                             |                                                                                                                                                                                                                                                               |
+| 0.5.0 | 1.0.0  | Added prefetch job that can heat up caches                                                                                                                                                                                 |                                                                                                                                                                                                                                                               |
+| 0.4.0 | 1.0.0  | Support for PWA Hybrid Approach deployment (with ICM 11)                                                                                                                                                                   | Requires PWA 3.2.0 for Hybrid Approach support                                                                                                                                                                                                                |
+| 0.3.0 | 1.0.0  | Use new Ingress controller definition                                                                                                                                                                                      | See [Migration to 0.3.0](https://github.com/intershop/helm-charts/blob/main/charts/pwa/docs/migrate-to-0.3.0.md)                                                                                                                                              |
+| 0.2.4 | 0.25.0 | Support for `multiChannel`, `cacheIgnoreParams` and `extraEnvVars` for nginx/cache deployment                                                                                                                              | Missing support for `multi-channel.yaml` and `caching-ignore-params.yaml` source code fallbacks                                                                                                                                                               |
+| 0.2.3 | 0.25.0 | Legacy Helm Chart 0.2.3 as initial version                                                                                                                                                                                 |                                                                                                                                                                                                                                                               |
 
 ## Parameters
 
@@ -105,7 +35,6 @@ These actions will be described as part of the release documentation available o
 | Name             | Description                    | Example Value                                |
 | ---------------- | ------------------------------ | -------------------------------------------- |
 | `updateStrategy` | The Kubernetes update strategy | `Recreate`<br>`RollingUpdate`&nbsp;(default) |
-
 
 ### NGINX
 
@@ -118,40 +47,13 @@ These actions will be described as part of the release documentation available o
 
 Both `cacheIgnoreParams` and `multiChannel` parameters take precedence over any `extraEnvVars` value containing `MULTI_CHANNEL` or `CACHING_IGNORE_PARAMS` variables.
 
-### SSR (Server-Side Rendering)
+### Hybrid Approach
 
 | Name                     | Description                                  | Example Value |
 | ------------------------ | -------------------------------------------- | ------------- |
 | `hybrid.enabled`         | Enable or disable Hybrid Approach deployment | `true`        |
 | `hybrid.backend.service` | ICM Web Adapter service name                 | `icm-web`     |
 | `hybrid.backend.port`    | ICM Web Adapter service port                 | `443`         |
-
-## Hybrid Approach
-
-Installs the [Intershop PWA and ICM system](https://github.com/intershop/intershop-pwa) all together in a Kubernetes cluster environment (same namespace). For more information about the Hybrid Approach, refer to the official [hybrid Approach concept](https://github.com/intershop/intershop-pwa/blob/develop/docs/concepts/hybrid-approach.md).
-
-To configure the PWA Helm chart for this mode, you must first set `hybrid.enabled` to `true`. This will activate conditional dependencies to an umbrella chart `icm`, which depends on `icm-as` and `icm-web`. Both require individual configuration. Please refer to their documentation for details. Finally, you must add each configuration values object to the `values.yaml` file that reflects your deployment.
-
-Example:
-
-```yaml
-image:
-  repository: intershophub/intershop-pwa-ssr
----
-cache:
-  image:
-    repository: intershophub/intershop-pwa-nginx
----
-icm:
-  icm-as:
-    image:
-      repository: intershophub/icm-as
----
-icm-web:
-  webadapter:
-    image:
-      repository: intershophub/icm-webadapter
-```
 
 ## NGINX Cache Prefetch
 
@@ -226,11 +128,13 @@ ingresssplit:
   tls:
   - secretName: tls-star-pwa-intershop-de
 ```
+
 Please pay attention to which API version of networking.k8s.io you are using. Check [this document](/charts/pwa/docs/migrate-to-0.3.0.md) for differences between the implementations.
 
 ## Pod Labels
 
 To introduce specific labels for the Pods needed for monitoring, change your values file or HelmRelease to the following:
+
 ```yaml
 ### @param podLabels labels for SSR pods and deployment
 ### ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -256,7 +160,101 @@ metrics:
 
 When enabled, the SSR container will expose the metrics in the deployment cluster on port 9113, while the nginx container exposes its metrics on port 9114 at the `/metrics` endpoint.
 
+## Hybrid Approach
+
+Installs the [Intershop PWA and ICM system](https://github.com/intershop/intershop-pwa) all together in a Kubernetes cluster environment (same namespace). For more information about the Hybrid Approach, refer to the official [hybrid Approach concept](https://github.com/intershop/intershop-pwa/blob/develop/docs/concepts/hybrid-approach.md).
+
+To configure the PWA Helm chart for this mode, you must first set `hybrid.enabled` to `true`. This will activate conditional dependencies to an umbrella chart `icm`, which depends on `icm-as` and `icm-web`. Both require individual configuration. Please refer to their documentation for details. Finally, you must add each configuration values object to the `values.yaml` file that reflects your deployment.
+
+Example:
+
+```yaml
+image:
+  repository: intershophub/intershop-pwa-ssr
 ---
+cache:
+  image:
+    repository: intershophub/intershop-pwa-nginx
+---
+icm:
+  icm-as:
+    image:
+      repository: intershophub/icm-as
+---
+icm-web:
+  webadapter:
+    image:
+      repository: intershophub/icm-webadapter
+```
+
+## Deployment via Flux Repository
+
+### Using [Flux](https://fluxcd.io) v1
+
+```yaml
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: xxx-yyy
+  namespace: xxx-yyy
+
+spec:
+  rollback:
+    enable: true
+    force: true
+  wait: true
+  timeout: 270
+  releaseName: xxx-yyy
+  chart:
+    repository: https://intershop.github.io/helm-charts
+    name: pwa-main
+    version: 0.7.0
+  values:
+```
+
+### Using [Flux](https://fluxcd.io) v2
+
+Here you create a HelmRepository resource in addition to the HelmRelease [(helm-operator-migration Guide from Flux v1 to Flux v2)](https://fluxcd.io/flux/migration/helm-operator-migration/)
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ish-helm-charts
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  url: https://intershop.github.io/helm-charts
+
+---
+# PWA HelmRelease
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ${namespace}
+  namespace: ${namespace}
+spec:
+  chart:
+    spec:
+      # pwa helm chart, version from https://github.com/intershop/helm-charts
+      chart: pwa-main
+      version: 0.7.0
+      # Source reference to the HelmChart Repo
+      sourceRef:
+        kind: HelmRepository
+        name: ish-helm-charts
+        namespace: flux-system
+  # in case multiple pwa instances will be deployed into the given environment namespace, a postfix has to be added to the
+  # release name (i.e. pwa-$ENVIRONMENT-01 or pwa-$ENVIRONMENT-edit)
+  releaseName: ${namespace}
+  targetNamespace: ${namespace}
+  interval: 1m0s
+  timeout:
+    5m0s
+    # Helm Values - to be adapted by the dev team
+  values:
+```
 
 ## Development
 

--- a/charts/pwa/ci/cache-channels.yaml
+++ b/charts/pwa/ci/cache-channels.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../values.schema.json
 replicaCount: 5
 image:
   repository: intershophub/intershop-pwa-ssr

--- a/charts/pwa/templates/NOTES.txt
+++ b/charts/pwa/templates/NOTES.txt
@@ -1,20 +1,24 @@
-1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
+Application is available on the following URL(s):
 {{- range $host := .Values.ingress.hosts }}
-  {{- range $.Values.ingress.paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- range $host.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
+Get the application URL by running these commands:
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "pwa-main.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ include "pwa-main.fullname" . }}'
+It may take a few minutes for the LoadBalancer IP to be available.
+You can watch the status of by running 'kubectl get svc -w {{ include "pwa-main.fullname" . }}'
+
+Get the application URL by running these commands:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "pwa-main.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
+Get the application URL by running these commands:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pwa-main.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80

--- a/charts/pwa/templates/deployment.yaml
+++ b/charts/pwa/templates/deployment.yaml
@@ -11,6 +11,8 @@ metadata:
     {{- toYaml .Values.podLabels | nindent 4 }}
     {{- end }}
 spec:
+  strategy:
+    type: {{ default "RollingUpdate" .Values.updateStrategy }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/pwa/templates/deployment_cache.yaml
+++ b/charts/pwa/templates/deployment_cache.yaml
@@ -91,6 +91,18 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.cache.resources | nindent 12 }}
+      initContainers:
+        - name: init-pwa
+          image: busybox:1.28
+          command:
+            - sh
+            - -c
+            - >-
+              until nc -zvw1 {{ include "pwa-main.fullname" . }} {{ .Values.service.port }};
+              do
+                echo "waiting for {{ include "pwa-main.fullname" . }}:{{ .Values.service.port }}";
+                sleep 2;
+              done
       volumes:
       - name: multi-channel-config
         configMap:

--- a/charts/pwa/templates/deployment_cache.yaml
+++ b/charts/pwa/templates/deployment_cache.yaml
@@ -11,6 +11,8 @@ metadata:
     {{- toYaml .Values.cache.podLabels | nindent 4 }}
     {{- end }}
 spec:
+  strategy:
+    type: {{ default "RollingUpdate" .Values.updateStrategy }}
   replicas: {{ .Values.cache.replicaCount }}
   selector:
     matchLabels:

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -6,7 +6,6 @@
     "description": "The Helm Values Schema to define values necessary to deploy Intershops PWA.",
     "required": [
         "upstream",
-        "hybrid",
         "environment",
         "cache"
     ],

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -11,6 +11,16 @@
         "cache"
     ],
     "properties": {
+        "updateStrategy": {
+          "type": "string",
+          "title": "Update strategy",
+          "description": "Kubernetes update strategy",
+          "default": "RollingUpdate",
+          "enum": [
+            "RollingUpdate",
+            "Recreate"
+          ]
+        },
         "upstream": {
             "$id": "#/properties/upstream",
             "type": "object",

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -1,3 +1,6 @@
+# install VSCode plugin redhat.vscode-yaml
+# yaml-language-server: $schema=./values.schema.json
+
 # Default values for pwa-main.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -1,6 +1,10 @@
 # Default values for pwa-main.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+updateStrategy: RollingUpdate
+# updateStrategy: Recreate
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

- Default rolling update can cause that new nginx instances cache old ssr content.

## What Is the New Behavior?

- ~~Both nginx and ssr have to be in sync all the time, so the strategy `Recreate` is used.~~
- Added initContainer for nginx waiting on pwa availability
- repaired notes
- The update strategy is configurable so now `Recreate` can be used when problems appear. (Default behavior is still `RollingUpdate`)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information
