### PR TITLE
feat: support secrets store csi v1  (#384)

### DIFF
--- a/charts/icm-as/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-as/templates/ssl-certificate-spc.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sslCertificateRetrieval.enabled }}
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: {{ include "icm-as.fullname" . }}-cert

--- a/charts/icm-as/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-as/templates/ssl-certificate-spc.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.sslCertificateRetrieval.enabled }}
+{{- if .Values.sslCertificateRetrieval.supportV1 }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
+{{- else }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+{{- end }}
 kind: SecretProviderClass
 metadata:
   name: {{ include "icm-as.fullname" . }}-cert

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -335,6 +335,7 @@ webLayer:
 
 sslCertificateRetrieval:
   enabled: false
+  supportV1: false
   # secretName: <explicit-ssl-secret-name>
   keyvault:
     tenantId: <tenant-ID-of-the-KeyVault>

--- a/charts/icm-web/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-web/templates/ssl-certificate-spc.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.webadapter.sslCertificateRetrieval.enabled }}
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: {{ include "icm-web.fullname" . }}-wa-spc-cert

--- a/charts/icm-web/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-web/templates/ssl-certificate-spc.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.webadapter.sslCertificateRetrieval.enabled }}
+{{- if .Values.webadapter.sslCertificateRetrieval.supportV1 }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
+{{- else }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+{{- end }}
 kind: SecretProviderClass
 metadata:
   name: {{ include "icm-web.fullname" . }}-wa-spc-cert

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -38,6 +38,7 @@ webadapter:
   updateStrategy: RollingUpdate
   sslCertificateRetrieval:
     enabled: false
+    supportV1: false
     # secretName: <explicit-ssl-secret-name>
     keyvault:
       tenantId: <tenant-ID-of-the-KeyVault>


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [x] Application / infrastructure changes

## Release ##

Be sure to include PR label `major`, `minor` or `patch` when merging into `main`. This determines which part of the semantic version number needs to be bumped automatically.

## What Is the Current Behavior?

The current helm chart icm-web and icm-as don't support new K8s version. Because
`apiVersion: secrets-store.csi.x-k8s.io/v1alpha1` is used.

This PR allows using `apiVersion: secrets-store.csi.x-k8s.io/v1` as well.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #384 

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information

to enable the _secrets-store.csi.x-k8s.io/v1_ please use:

```
sslCertificateRetrieval:
  supportV1: true
```

In the new major version, this default configuration will be changed to "true", so that usage of deprecated v1apha1 will be supported additionally.