### PR TITLE
refactor: new ingress format

### DIFF
--- a/charts/pwa/ci/cache-channels.yaml
+++ b/charts/pwa/ci/cache-channels.yaml
@@ -43,8 +43,7 @@ cache:
 ingress:
   enabled: true
   className: nginx
-  hosts:
-    - host: pwa.example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  instances:
+    ingress:
+      hosts:
+        - host: pwa.example.local

--- a/charts/pwa/docs/migrate-to-0.8.0.md
+++ b/charts/pwa/docs/migrate-to-0.8.0.md
@@ -1,0 +1,76 @@
+# Migration to 0.8.0
+
+## Simplified Ingress Declarations
+
+The `ingress` and `ingresssplit` configurations were combined to only support one `ingress` object that can declare multiple instances.
+We also dropped support for supplying paths because it is not working for the PWA standard deployment.
+
+Old:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/tls-acme: "false"
+  hosts:
+    - host: pwa.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: tls-star-pwa-intershop-de
+
+ingresssplit:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/tls-acme: "false"
+    configuration-snippet: |-
+      satisfy any;
+      allow xxx.xxx.xxx.xxx;
+      deny all;
+  hosts:
+    - host: pwa-test.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+    - host: pwa2-test.example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: tls-star-pwa-intershop-de
+```
+
+New:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  instances:
+    ingress:
+      annotations:
+        kubernetes.io/tls-acme: "false"
+      tlsSecretName: tls-star-pwa-intershop-de
+      hosts:
+        - host: pwa.example.local
+    ingresssplit:
+      annotations:
+        kubernetes.io/tls-acme: "false"
+        configuration-snippet: |-
+          satisfy any;
+          allow xxx.xxx.xxx.xxx;
+          deny all;
+      tlsSecretName: tls-star-pwa-intershop-de
+      hosts:
+        - host: pwa-test.example.local
+        - host: pwa2-test.example.local
+```
+
+## Removed Handling of older Kubernetes Clusters
+
+Please pay attention to which API version of networking.k8s.io you are using.
+Check [this document](/charts/pwa/docs/migrate-to-0.3.0.md) for differences between the implementations.
+For the sake of chart readability the PWA Helm Chart 0.8.0 only supports the new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1).

--- a/charts/pwa/templates/NOTES.txt
+++ b/charts/pwa/templates/NOTES.txt
@@ -1,10 +1,6 @@
 {{- if .Values.ingress.enabled }}
-Application is available on the following URL(s):
-{{- range $host := .Values.ingress.hosts }}
-  {{- range $host.paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
+Get the application URL by running this command:
+  kubectl get --namespace {{ .Release.Namespace }} ingress
 {{- else if contains "NodePort" .Values.service.type }}
 Get the application URL by running these commands:
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "pwa-main.fullname" . }})
@@ -18,8 +14,7 @@ Get the application URL by running these commands:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "pwa-main.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-Get the application URL by running these commands:
+Get the application by running these commands and opening http://127.0.0.1:8080 to use the application afterwards:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pwa-main.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:4200
 {{- end }}

--- a/charts/pwa/templates/ingress.yaml
+++ b/charts/pwa/templates/ingress.yaml
@@ -1,131 +1,71 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "pwa-ingress.service" . -}}
-{{- $svcPort := .Values.cache.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{ range $name, $value := .Values.ingress.instances }}
+{{ with $value }}
+{{/* create a map tlsSecret <- hosts */}}
+{{- $tlsDict := dict -}}
+{{- $rootSecret := .tlsSecretName -}}
+{{- if $rootSecret -}}
+  {{/* add empty list for root secret hosts */}}
+  {{- $tlsDict = dict $rootSecret list -}}
+{{- end }}
+{{- range .hosts }}
+  {{- if .tlsSecretName }}
+    {{/* host has an override, add it to the (new) list for this secret */}}
+    {{- if not (hasKey $tlsDict .tlsSecretName) }}
+      {{- $tlsDict = set $tlsDict .tlsSecretName (list .host) -}}
+    {{- else  }}
+      {{- $tlsDict = set $tlsDict .tlsSecretName (append (get $tlsDict .tlsSecretName) .host ) -}}
+    {{- end }}
+  {{- else if $rootSecret }}
+    {{/* host does not have override, add to root secret list */}}
+    {{- $tlsDict = set $tlsDict $rootSecret (append (get $tlsDict $rootSecret) .host ) -}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if $rootSecret -}}
+  {{- if not (get $tlsDict $rootSecret) -}}
+    {{/* unset root secret list if empty */}}
+    {{- $tlsDict = unset $tlsDict $rootSecret -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "pwa-cache.fullname" $ }}-{{ $name }}
   labels:
-    app.kubernetes.io/name: {{ include "pwa-main.name" . }}
-    helm.sh/chart: {{ include "pwa-main.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
+    app.kubernetes.io/name: {{ include "pwa-main.name" $ }}
+    helm.sh/chart: {{ include "pwa-main.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+  {{- if .annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
+  ingressClassName: {{ $.Values.ingress.className }}
+  {{- with $tlsDict }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
+  {{- range $tlsSecret, $hosts := . }}
+    - secretName: {{ $tlsSecret }}
+      hosts:
+      {{- range $hosts }}
         - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      {{- end }}
+  {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+  {{- range .hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+          - path: /
+            pathType: ImplementationSpecific
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ include "pwa-cache.fullname" $ }}
                 port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
-{{- end }}
-
+                  number: {{ $.Values.cache.service.port }}
+  {{- end }}
 ---
-
-{{- if .Values.ingresssplit.enabled -}}
-{{- $fullName := include "pwa-ingress.service" . -}}
-{{- $svcPort := .Values.cache.service.port -}}
-{{- if and .Values.ingresssplit.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingresssplit.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingresssplit.annotations "kubernetes.io/ingress.class" .Values.ingresssplit.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}-split
-  labels:
-    app.kubernetes.io/name: {{ include "pwa-main.name" . }}
-    helm.sh/chart: {{ include "pwa-main.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingresssplit.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingresssplit.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingresssplit.className }}
-  {{- end }}
-  {{- if .Values.ingresssplit.tls }}
-  tls:
-    {{- range .Values.ingresssplit.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingresssplit.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{ end }}
+{{ end }}
 {{- end }}

--- a/charts/pwa/values.schema.json
+++ b/charts/pwa/values.schema.json
@@ -258,6 +258,79 @@
                 }
               }
           }
+        },
+        "ingress": {
+          "additionalProperties": false,
+          "type": "object",
+          "title": "Ingress configuration",
+          "description": "Configure the ingress for the PWA",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable ingress",
+              "description": "Enable ingress",
+              "default": false
+            },
+            "className": {
+              "type": "string",
+              "title": "Ingress class name",
+              "description": "Ingress class name",
+              "default": "nginx"
+            },
+            "instances": {
+              "type": "object",
+              "title": "Ingress instances",
+              "description": "Configure different ingress instances",
+              "additionalProperties": {
+                "type": "object",
+                "title": "Ingress instance",
+                "description": "Ingress instance",
+                "additionalProperties": false,
+                "properties": {
+                  "tlsSecretName": {
+                    "type": "string",
+                    "title": "TLS secret name",
+                    "description": "TLS secret name"
+                  },
+                  "annotations": {
+                    "type": "object",
+                    "title": "Ingress Annotations",
+                    "description": "Ingress Annotations",
+                    "default": {},
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "title": "Ingress hosts",
+                    "description": "Ingress hosts",
+                    "default": [],
+                    "items": {
+                      "type": "object",
+                      "title": "Ingress host",
+                      "description": "Ingress host",
+                      "additionalProperties": false,
+                      "required": ["host"],
+                      "properties": {
+                        "host": {
+                          "type": "string",
+                          "title": "Host name",
+                          "description": "Host name",
+                          "default": ""
+                        },
+                        "tlsSecretName": {
+                          "type": "string",
+                          "title": "TLS secret name override",
+                          "description": "TLS secret name override for this host"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
     }
 }

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -188,32 +188,8 @@ cache:
   readinessProbe: {}
 
 ingress:
-  enabled: true
-  className: nginx
-  annotations: {}
-  hosts:
-    - host: pwa.example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-ingresssplit:
   enabled: false
   className: nginx
-  annotations: {}
-  hosts:
-    - host: pwa1.example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 # Calculated values
 # use with `{{ tpl $.Values.calculated.X.Y $ }}`


### PR DESCRIPTION
## PR Type

[x] Application / infrastructure changes

## Release ##

major

## What Is the Current Behavior?

- The ingress declaration supposedly enables the PWA to be deploued flexible in a context path, which will not work
- The `ingresssplit` definition with b4cab60 introduces a lot of code duplication.

## What Is the New Behavior?

- new format of declaring ingress
- removed declarable paths
- removed duplication
- removed handling of older kubernetes clusters for the sake of chart readability

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

[x] Yes
[ ] No

## Other Information
