### PR TITLE
Support Several JGroups Discovery Modes

### DIFF
--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -7,6 +7,8 @@ Creates the environment section
 env:
 - name: ENVIRONMENT
   value: "{{ include "icm-as.environmentName" . }}"
+- name: INTERSHOP_EVENT_JGROUPSPROTOCOLSTACKCONFIGFILE
+  value: "/intershop/jgroups-conf/jgroups-config.xml"
 {{- if not (hasKey .Values.environment "SERVER_NAME") }}
 - name: SERVER_NAME
   value: "{{ .Values.serverName }}"

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -175,3 +175,19 @@ securityContext:
   {{- toYaml .Values.podSecurityContext | nindent 2 }}
 {{- end }}
 {{- end -}}
+
+{{/*
+The discovery mode of jgroups messaging
+*/}}
+{{- define "icm-as.jgroups.discovery" -}}
+{{- if .Values.jgroups -}}
+  {{- if .Values.jgroups.discovery -}}
+    {{- .Values.jgroups.discovery -}}
+  {{- else -}}
+    {{- printf "file_ping" }}
+  {{- end -}}
+{{- else -}}
+    {{- printf "file_ping" }}
+{{- end -}}
+{{- end -}}
+

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -55,11 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "icm-as.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "icm-as.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
+  {{ default (printf "%s-%s" (include "icm-as.fullname" .) "default") .Values.serviceAccount.name }}
 {{- end -}}
 
 {{/*
@@ -119,6 +115,7 @@ annotations:
 Pod-labels
 */}}
 {{- define "icm-as.podLabels" -}}
+jgroupscluster: "{{- .Values.jgroups.clusterLabel | default .Release.Name -}}"
 {{- with .Values.podLabels }}
 {{- . | toYaml | nindent 0 }}
 {{- end }}

--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -18,12 +18,16 @@ initContainers:
   - "-c"
   - |
     chmod 777 /intershop/sites && chown -R 150:150 /intershop/sites
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" }}
     chmod 777 /intershop/jgroups-share && chown -R 150:150 /intershop/jgroups-share
+{{- end }}
   volumeMounts:
   - name: sites-volume
     mountPath: /intershop/sites
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" }}
   - name: jgroups-volume
     mountPath: /intershop/jgroups-share
+{{- end }}
   securityContext:
     runAsUser: 0
 {{- end }}

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -27,6 +27,10 @@ volumeMounts:
   readOnly: true
   subPath: replication-clusters.xml
 {{- end }}
+- mountPath: /intershop/jgroups-conf/jgroups-config.xml
+  name: jgroups-config-volume
+  readOnly: true
+  subPath: jgroups-config.xml
 {{- if .Values.webLayer.redis.enabled }}
 - mountPath: /intershop/redis-conf/redis-client-config.yaml
   name: redis-client-config-volume

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -19,8 +19,10 @@ volumeMounts:
 {{- end }}
 - mountPath: /intershop/customizations
   name: customizations-volume
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" }}
 - mountPath: /intershop/jgroups-share
   name: jgroups-volume
+{{- end }}
 {{- if and (.Values.replication.enabled) (eq .Values.replication.role "source")}}
 - mountPath: /intershop/replication-conf/replication-clusters.xml
   name: replication-volume

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -18,7 +18,9 @@ volumes:
     defaultMode: 420
     name: {{ template "icm-as.fullname" . }}-newrelic-yml
 {{- end }}
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" }}
 {{- include "icm-as.volume" (list . "jgroups" .Values.persistence.jgroups .Values.podSecurityContext) }}
+{{- end }}
 {{- include "icm-as.volume" (list . "sites" .Values.persistence.sites .Values.podSecurityContext) }}
 {{- if and (.Values.replication.enabled) (eq .Values.replication.role "source")}}
 - name: replication-volume
@@ -30,11 +32,9 @@ volumes:
   configMap:
     name: {{ template "icm-as.fullname" . }}-redis-client-config-yaml
 {{- end }}
-{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" -}}
 - name: jgroups-config-volume
   configMap:
     name: {{ template "icm-as.fullname" . }}-jgroups-config-xml
-{{- end }}
 {{- if .Values.persistence.customdata.enabled }}
 - name: custom-data-volume
   persistentVolumeClaim:

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -30,6 +30,11 @@ volumes:
   configMap:
     name: {{ template "icm-as.fullname" . }}-redis-client-config-yaml
 {{- end }}
+{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" -}}
+- name: jgroups-config-volume
+  configMap:
+    name: {{ template "icm-as.fullname" . }}-jgroups-config-xml
+{{- end }}
 {{- if .Values.persistence.customdata.enabled }}
 - name: custom-data-volume
   persistentVolumeClaim:

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -43,8 +43,8 @@ spec:
           {{- include "icm-as.podBinding" . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ include "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+      {{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
+      serviceAccountName: {{ include "icm-as.serviceAccountName" . }}
       {{- end }}
       {{- if include "icm-as.nodeSelector" . }}
         {{- include "icm-as.nodeSelector" . | nindent 6 }}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -43,6 +43,7 @@ spec:
           {{- include "icm-as.podBinding" . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
       {{- if include "icm-as.nodeSelector" . }}
         {{- include "icm-as.nodeSelector" . | nindent 6 }}
       {{- end }}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -43,7 +43,9 @@ spec:
           {{- include "icm-as.podBinding" . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+      {{- end }}
       {{- if include "icm-as.nodeSelector" . }}
         {{- include "icm-as.nodeSelector" . | nindent 6 }}
       {{- end }}

--- a/charts/icm-as/templates/cluster-jgroups-pvc.yaml
+++ b/charts/icm-as/templates/cluster-jgroups-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" -}}
 {{- if eq .Values.persistence.jgroups.type "cluster" -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -15,4 +16,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.jgroups.size }}
+{{- end -}}
 {{- end -}}

--- a/charts/icm-as/templates/jgroups-config-xml-cm.yaml
+++ b/charts/icm-as/templates/jgroups-config-xml-cm.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "icm-as.fullname" . }}-jgroups-config-xml
+  labels:
+    app: {{ template "icm-as.fullname" . }}-jgroups-config-xml
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  jgroups-config.xml:  |-
+    <!--
+      Default stack using IP multicasting. It is similar to the "udp"
+      stack in stacks.xml, but doesn't use streaming state transfer and flushing
+      author: Bela Ban
+      
+      ISH-addition: use different discovery types
+    -->
+    <config xmlns="urn:org:jgroups"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd"
+            version="5.2.13.Final">
+        <UDP
+            bind_port="7800"
+            ip_mcast="false"
+            tos="8"
+            ucast_recv_buf_size="20000000"
+            ucast_send_buf_size="640000"
+            mcast_recv_buf_size="25000000"
+            mcast_send_buf_size="640000"
+            bundler.max_size="64000"
+
+            ip_ttl="${jgroups.udp.ip_ttl:2}"
+
+            thread_naming_pattern="cl"
+            thread_pool.enabled="true"
+            thread_pool.min_threads="4"
+            thread_pool.max_threads="64"
+            thread_pool.keep_alive_time="10000"
+        />
+
+{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" -}}
+        <!-- discover nodes using KUBE_PING  -->
+        <org.jgroups.protocols.kubernetes.KUBE_PING
+          port_range="5"
+        />
+{{- else -}}
+        <!-- discover nodes by shared FS. may be replaced by static TCP configuration -->
+        <FILE_PING
+          location="/intershop/jgroups-share"
+          remove_old_coords_on_view_change="true"
+          remove_all_data_on_view_change="true"
+          write_data_on_find="true"
+        />
+{{- end -}}
+
+        <MERGE3 max_interval="30000"
+                min_interval="10000"/>
+        <FD_SOCK/>
+        <FD_ALL2 timeout="12000" interval="3000"/>
+        <VERIFY_SUSPECT timeout="1500"  />
+
+        <pbcast.NAKACK2 xmit_interval="500"
+                        xmit_table_num_rows="100"
+                        xmit_table_msgs_per_row="2000"
+                        xmit_table_max_compaction_time="30000"
+                        use_mcast_xmit="false"
+                        discard_delivered_msgs="false"/>
+        <UNICAST3 xmit_interval="500"
+                  xmit_table_num_rows="100"
+                  xmit_table_msgs_per_row="2000"
+                  xmit_table_max_compaction_time="60000"
+                  conn_expiry_timeout="0"/>
+        <pbcast.STABLE desired_avg_gossip="50000"
+                      max_bytes="400000"/>
+        <pbcast.GMS print_local_addr="true"
+                    join_timeout="1000"
+                    max_join_attempts="5"/>
+        <UFC max_credits="2000000"
+              min_threshold="0.2"/>
+        <FRAG2 frag_size="60000"  />
+        <RSVP resend_interval="2000" timeout="10000"/>
+        <pbcast.STATE/>
+    </config>

--- a/charts/icm-as/templates/jgroups-config-xml-cm.yaml
+++ b/charts/icm-as/templates/jgroups-config-xml-cm.yaml
@@ -41,21 +41,22 @@ data:
         <!-- discover nodes using KUBE_PING -->
         <org.jgroups.protocols.kubernetes.KUBE_PING
           namespace="{{.Release.Namespace}}"
-          port_range="5"
-{{- else if eq (include "icm-as.jgroups.discovery" .) "file_ping" -}}
+          labels="jgroupscluster={{- .Values.jgroups.clusterLabel | default .Release.Name -}}"
+          port_range="{{- .Values.jgroups.portRange | default 5 -}}"
+{{- else if eq (include "icm-as.jgroups.discovery" .) "file_ping" }}
         <!-- discover nodes by shared FS -->
         <FILE_PING
           location="/intershop/jgroups-share"
           remove_old_coords_on_view_change="true"
           remove_all_data_on_view_change="true"
           write_data_on_find="true"
-{{- else if eq (include "icm-as.jgroups.discovery" .) "azure_ping" -}}
+{{- else if eq (include "icm-as.jgroups.discovery" .) "azure_ping" }}
         <!-- discover nodes using azure protocol -->
         <azure.AZURE_PING
           storage_account_name="${jgroups.azure_ping.storage_account_name}"
           storage_access_key="${jgroups.azure_ping.storage_access_key}"
           container="${jgroups.azure_ping.container:ping}"
-{{- else if eq (include "icm-as.jgroups.discovery" .) "dns_ping" -}}
+{{- else if eq (include "icm-as.jgroups.discovery" .) "dns_ping" }}
         <!-- discover nodes using azure protocol -->
         <dns.DNS_PING 
           dns_query="{{ .Values.jgroups.dnsQuery }}"

--- a/charts/icm-as/templates/jgroups-config-xml-cm.yaml
+++ b/charts/icm-as/templates/jgroups-config-xml-cm.yaml
@@ -11,13 +11,13 @@ data:
       Default stack using IP multicasting. It is similar to the "udp"
       stack in stacks.xml, but doesn't use streaming state transfer and flushing
       author: Bela Ban
-      
+
       ISH-addition: use different discovery types
     -->
     <config xmlns="urn:org:jgroups"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd"
-            version="5.2.13.Final">
+            version="5.3.0.Final">
         <UDP
             bind_port="7800"
             ip_mcast="false"
@@ -37,20 +37,35 @@ data:
             thread_pool.keep_alive_time="10000"
         />
 
-{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" -}}
-        <!-- discover nodes using KUBE_PING  -->
+{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
+        <!-- discover nodes using KUBE_PING -->
         <org.jgroups.protocols.kubernetes.KUBE_PING
+          namespace="{{.Release.Namespace}}"
           port_range="5"
-        />
-{{- else -}}
-        <!-- discover nodes by shared FS. may be replaced by static TCP configuration -->
+{{- else if eq (include "icm-as.jgroups.discovery" .) "file_ping" -}}
+        <!-- discover nodes by shared FS -->
         <FILE_PING
           location="/intershop/jgroups-share"
           remove_old_coords_on_view_change="true"
           remove_all_data_on_view_change="true"
           write_data_on_find="true"
+{{- else if eq (include "icm-as.jgroups.discovery" .) "azure_ping" -}}
+        <!-- discover nodes using azure protocol -->
+        <azure.AZURE_PING
+          storage_account_name="${jgroups.azure_ping.storage_account_name}"
+          storage_access_key="${jgroups.azure_ping.storage_access_key}"
+          container="${jgroups.azure_ping.container:ping}"
+{{- else if eq (include "icm-as.jgroups.discovery" .) "dns_ping" -}}
+        <!-- discover nodes using azure protocol -->
+        <dns.DNS_PING 
+          dns_query="{{ .Values.jgroups.dnsQuery }}"
+{{- end }}
+          {{- if .Values.jgroups -}}
+            {{- if .Values.jgroups.discoveryExtraAttributes }}
+          {{ .Values.jgroups.discoveryExtraAttributes }}
+            {{- end -}}
+          {{- end -}}
         />
-{{- end -}}
 
         <MERGE3 max_interval="30000"
                 min_interval="10000"/>

--- a/charts/icm-as/templates/jgroups-kubeping-cr.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-cr.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jgroups-kubeping-pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]

--- a/charts/icm-as/templates/jgroups-kubeping-cr.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-cr.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
+{{- if .Values.serviceAccount.create -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/icm-as/templates/jgroups-kubeping-cr.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-cr.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -6,3 +7,4 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]
+{{ end }}

--- a/charts/icm-as/templates/jgroups-kubeping-crb.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-crb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jgroups-kubeping-api-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jgroups-kubeping-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ template "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+  # jgroups-kubeping-service-account
+  namespace: {{.Release.Namespace}}

--- a/charts/icm-as/templates/jgroups-kubeping-crb.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-crb.yaml
@@ -2,14 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: jgroups-kubeping-api-access
+  name: {{ template "icm-as.fullname" . }}-jgroups-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: jgroups-kubeping-pod-reader
 subjects:
 - kind: ServiceAccount
-  name: {{ template "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
-  # jgroups-kubeping-service-account
+  name: {{ include "icm-as.serviceAccountName" . }}
   namespace: {{.Release.Namespace}}
 {{ end }}

--- a/charts/icm-as/templates/jgroups-kubeping-crb.yaml
+++ b/charts/icm-as/templates/jgroups-kubeping-crb.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -11,3 +12,4 @@ subjects:
   name: {{ template "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
   # jgroups-kubeping-service-account
   namespace: {{.Release.Namespace}}
+{{ end }}

--- a/charts/icm-as/templates/jobserver-deployment.yaml
+++ b/charts/icm-as/templates/jobserver-deployment.yaml
@@ -36,6 +36,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: {{ include "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+          {{- end }}
           {{- if include "icm-as.nodeSelector" $jobValues }}
             {{- include "icm-as.nodeSelector" $jobValues | nindent 10 }}
           {{- end }}

--- a/charts/icm-as/templates/jobserver-deployment.yaml
+++ b/charts/icm-as/templates/jobserver-deployment.yaml
@@ -36,8 +36,8 @@ spec:
     spec:
       template:
         spec:
-          {{- if .Values.serviceAccount.create }}
-          serviceAccountName: {{ include "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+          {{- if eq (include "icm-as.jgroups.discovery" .) "kube_ping" }}
+          serviceAccountName: {{ include "icm-as.serviceAccountName" . }}
           {{- end }}
           {{- if include "icm-as.nodeSelector" $jobValues }}
             {{- include "icm-as.nodeSelector" $jobValues | nindent 10 }}

--- a/charts/icm-as/templates/local-jgroups-pvc.yaml
+++ b/charts/icm-as/templates/local-jgroups-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "icm-as.jgroups.discovery" .) "file_ping" -}}
 {{- if eq .Values.persistence.jgroups.type "local" -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -11,4 +12,5 @@ spec:
     requests:
       storage: {{ .Values.persistence.jgroups.size }}
   volumeName: {{ template "icm-as.fullname" . }}-local-jgroups-pv
+{{- end -}}
 {{- end -}}

--- a/charts/icm-as/templates/serviceaccount.yaml
+++ b/charts/icm-as/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "icm-as.fullname" . }}-{{ include "icm-as.serviceAccountName" . }}
+  name: {{ include "icm-as.serviceAccountName" . }}
   labels:
     {{ include "icm-as.labels" . | indent 4 | trim }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/icm-as/tests/jgroups-config_test.yaml
+++ b/charts/icm-as/tests/jgroups-config_test.yaml
@@ -1,0 +1,58 @@
+suite: test correctness of jgroups-configuration
+templates:
+  - templates/jgroups-config-xml-cm.yaml
+tests:
+  - it: jgroups-config.xml default values uses FILE_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/jgroups-config-xml-cm.yaml
+    asserts:
+      - matchRegex:
+          path: data["jgroups-config.xml"]
+          pattern: <FILE_PING*
+  - it: jgroups-config.xml configured to use KUB_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/jgroups-config-xml-cm.yaml
+    set:
+      jgroups.discovery: "kube_ping"
+    asserts:
+      - matchRegex:
+          path: data["jgroups-config.xml"]
+          pattern: <org.jgroups.protocols.kubernetes.KUBE_PING
+  - it: jgroups-config.xml configured to use AZURE_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/jgroups-config-xml-cm.yaml
+    set:
+      jgroups.discovery: "azure_ping"
+    asserts:
+      - matchRegex:
+          path: data["jgroups-config.xml"]
+          pattern: <azure.AZURE_PING
+  - it: jgroups-config.xml configured to use DNS_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/jgroups-config-xml-cm.yaml
+    set:
+      jgroups.discovery: "dns_ping"
+    asserts:
+      - matchRegex:
+          path: data["jgroups-config.xml"]
+          pattern: <dns.DNS_PING

--- a/charts/icm-as/tests/jgroups-kubeping-cluster-roles_test.yaml
+++ b/charts/icm-as/tests/jgroups-kubeping-cluster-roles_test.yaml
@@ -1,0 +1,47 @@
+suite: tests correctness of cluster role bindings for jgroups KUBE_PING discovery
+templates:
+  - templates/jgroups-kubeping-cr.yaml
+  - templates/jgroups-kubeping-crb.yaml
+tests:
+  - it: no roles or role-bindings if KUBE_PING is not used
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: role jgroups KUBE_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: "templates/jgroups-kubeping-cr.yaml"
+    set:
+      jgroups.discovery: "kube_ping"
+    asserts:
+      - isKind:
+          of: ClusterRole
+  - it: role-binding jgroups KUBE_PING
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: "templates/jgroups-kubeping-crb.yaml"
+    set:
+      jgroups.discovery: "kube_ping"
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: icm-as-default
+            namespace: NAMESPACE

--- a/charts/icm-as/tests/jgroups-kubeping-cluster-roles_test.yaml
+++ b/charts/icm-as/tests/jgroups-kubeping-cluster-roles_test.yaml
@@ -22,7 +22,7 @@ tests:
       - ../values.yaml
     template: "templates/jgroups-kubeping-cr.yaml"
     set:
-      jgroups.discovery: "kube_ping"
+      serviceAccount.create: true
     asserts:
       - isKind:
           of: ClusterRole

--- a/charts/icm-as/tests/serviceaccount-create_test.yaml
+++ b/charts/icm-as/tests/serviceaccount-create_test.yaml
@@ -1,6 +1,8 @@
 suite: tests correctness of serviceAccount
 templates:
   - templates/serviceaccount.yaml
+  - templates/as-deployment.yaml
+  - templates/jobserver-deployment.yaml
 tests:
   - it: create is false
     release:
@@ -9,6 +11,7 @@ tests:
       version: 0.8.15
     values:
       - ../values.yaml
+    template: serviceaccount.yaml
     set:
       serviceAccount.create: false
     asserts:
@@ -22,6 +25,7 @@ tests:
       version: 0.8.15
     values:
       - ../values.yaml
+    template: serviceaccount.yaml
     set:
       serviceAccount.create: true
     asserts:
@@ -38,6 +42,7 @@ tests:
       version: 0.8.15
     values:
       - ../values.yaml
+    template: serviceaccount.yaml
     set:
       serviceAccount.create: true
       serviceAccount.name: mycustomserviceaccount
@@ -55,6 +60,7 @@ tests:
       version: 0.8.15
     values:
       - ../values.yaml
+    template: serviceaccount.yaml
     set:
       serviceAccount.create: true
       serviceAccount.annotations.annotation0: zero
@@ -72,3 +78,33 @@ tests:
           path: metadata.annotations.annotation1
           value: one
 
+  - it: create is true, account set is as-deployment
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: as-deployment.yaml
+    set:
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: icm-as-icm-as
+
+  - it: create is true, account set is jobserver-deployment
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: jobserver-deployment.yaml
+    set:
+      serviceAccount.create: true
+      job.enabled: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: icm-as-icm-as

--- a/charts/icm-as/tests/serviceaccount-create_test.yaml
+++ b/charts/icm-as/tests/serviceaccount-create_test.yaml
@@ -33,7 +33,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: icm-as-icm-as
+          value: icm-as-default
 
   - it: create is true, name provided
     release:
@@ -51,7 +51,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: icm-as-mycustomserviceaccount
+          value: mycustomserviceaccount
 
   - it: create is true, annotations provided
     release:
@@ -70,7 +70,7 @@ tests:
           of: ServiceAccount
       - equal:
           path: metadata.name
-          value: icm-as-icm-as
+          value: icm-as-default
       - equal:
           path: metadata.annotations.annotation0
           value: zero
@@ -87,11 +87,11 @@ tests:
       - ../values.yaml
     template: as-deployment.yaml
     set:
-      serviceAccount.create: true
+      jgroups.discovery: kube_ping
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: icm-as-icm-as
+          value: icm-as-default
 
   - it: create is true, account set is jobserver-deployment
     release:
@@ -102,9 +102,9 @@ tests:
       - ../values.yaml
     template: jobserver-deployment.yaml
     set:
-      serviceAccount.create: true
+      jgroups.discovery: kube_ping
       job.enabled: true
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.serviceAccountName
-          value: icm-as-icm-as
+          value: icm-as-default

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -45,7 +45,7 @@ dockerSecret:
 ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 ## Intershop: These secrets also last for customization images
 imagePullSecrets:
-- "dockerhub"
+  - "dockerhub"
 
 # list of customization images each following the structure:
 #  <name>:
@@ -108,6 +108,7 @@ operationalContext:
 
 # provide custom cluster config from "icm-as.fullname"-system-conf-cluster configmap
 provideCustomConfig: {}
+
   # logback-main:
   #   mountPath: /intershop/system-conf/cluster/
   #   fileName: logback-main.xml
@@ -312,7 +313,8 @@ copySitesDir:
 ingress:
   enabled: false
   className: null
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # Paths are treated as list of prefixes. Any URL matching one of the prefixes will
@@ -386,3 +388,8 @@ replication:
 
   # the name of the (source) database to be used at the target-system to read data from e.g. intershop_edit
   sourceDatabaseName: <databaseName>
+# Configuration of messaging via jgroups
+#jgroups:
+# the discovery protocol to use
+# supported values are file_ping or kube_ping. Defaults to file_ping, but kube_ping is recommended
+# discovery: <kube_ping | file_ping>

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -107,7 +107,8 @@ operationalContext:
   applicationType: icm
 
 # provide custom cluster config from "icm-as.fullname"-system-conf-cluster configmap
-provideCustomConfig: {}
+provideCustomConfig:
+  {}
 
   # logback-main:
   #   mountPath: /intershop/system-conf/cluster/
@@ -388,8 +389,14 @@ replication:
 
   # the name of the (source) database to be used at the target-system to read data from e.g. intershop_edit
   sourceDatabaseName: <databaseName>
+
 # Configuration of messaging via jgroups
-#jgroups:
-# the discovery protocol to use
-# supported values are file_ping or kube_ping. Defaults to file_ping, but kube_ping is recommended
-# discovery: <kube_ping | file_ping>
+jgroups:
+  # the discovery protocol to use
+  # supported values are file_ping or kube_ping. Defaults to file_ping, but kube_ping | azure_ping is recommended
+  # discovery: <kube_ping | file_ping | azure_ping | dns_ping>
+  # extra attributes to be added at the ping-section in xml,
+  # e.g. "readTimeout=\"1000\" operationAttempts=\"5\""
+  # discoveryExtraAttributes: <extra-attributes>
+  # the DNS-query. Used with discovery type dns_ping
+  dnsQuery: <dnsQuery>

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -118,12 +118,11 @@ provideCustomConfig:
   #   fileName: urlrewriterules.xml
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # Specifies whether a service account should be created and used
   create: false
   # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # The name of the service account to use. (default .Release.Name + "-default")
   name:
 
 podSecurityContext:
@@ -392,11 +391,23 @@ replication:
 
 # Configuration of messaging via jgroups
 jgroups:
+
   # the discovery protocol to use
   # supported values are file_ping or kube_ping. Defaults to file_ping, but kube_ping | azure_ping is recommended
-  # discovery: <kube_ping | file_ping | azure_ping | dns_ping>
+  # file_ping (default) requires a mounted file system
+  # kube_ping (recommended) please set serviceAccount.create to create service account if not exists to allow icm to talk with k8s api server
+  # azure_ping (playground) mounts azure storage directly
+  # dns_ping (playground) declared dns query
+  discovery: file_ping
+
   # extra attributes to be added at the ping-section in xml,
   # e.g. "readTimeout=\"1000\" operationAttempts=\"5\""
   # discoveryExtraAttributes: <extra-attributes>
+
   # the DNS-query. Used with discovery type dns_ping
   dnsQuery: <dnsQuery>
+
+  # label for multiple clusters in a release (default: .Release.Name)
+  clusterLabel:
+  # adaption of ports in case a different range is needed
+  portRange:


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

This is a `minor` release allowing to configure jgroups-discovery modes.

## What Is the Current Behavior?

ICM-AS uses FILE_PING as jgroups discovery mode. To support that, a persistent volume is necessary and configured in the helm chart.
The ServiceAccount can be used in case the chart can create the account, only.

## What Is the New Behavior?

ICM-AS can now use different jgroups discovery modes. The most fitting mode is KUBE_PING. In order to allow to configure this mode a config map jgroups-config.xml is used and cluster roles and bindings are provided.
The service account can be created and used by jgroups, the configuration of the service account allows to define use an existing service account name.

## Does this PR Introduce a Breaking Change?
- [ ] Yes
- [x] No

## Other Information

To enable KUBE_PING, the icm-as pods are assigned to a service account. This service account has permissions to read pods inside the namespace.

