### PR TITLE
fix(icm): Deprecate icm-as.newrelic.license_key

### DIFF
--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -81,6 +81,8 @@ newrelic:
   #   application name (~= environment name): calculated from operationalContext section, set to override
   # app_name: "icm"
   # provide license key as plain text
+  # "license_key" deprecated since ICM-AS Helm Charts 1.8.0, will be removed in a future version.
+  # Use licenseKeySecretKeyRef instead.
   license_key: "secret"
   # instead use secret key reference (recommended) - takes precedence over license_key
   # licenseKeySecretKeyRef:


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Helm chart value configurations follow camel case, however the key "newrelic.license_key" does not.
For consistent naming - also in terms of alignment with the IOM helm charts - we should deprecate (and eventually remove) "license_key".

## What Is the New Behavior?

"license_key" is deprecated.
Fixes [AB#94232](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94232)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

