### PR TITLE
fix(icm): Deprecate icm-as.newrelic.app_name and provide appName instead

### DIFF
--- a/charts/icm-as/templates/config-newrelic-yaml-cm.yaml
+++ b/charts/icm-as/templates/config-newrelic-yaml-cm.yaml
@@ -9,5 +9,5 @@ metadata:
 data:
   newrelic.yml:  |-
     common: &default_settings
-      app_name : "{{ .Values.newrelic.app_name | default (include "icm-as.operationalContextName" .) }}"
+      app_name : "{{ .Values.newrelic.appName | default (.Values.newrelic.app_name | default (include "icm-as.operationalContextName" .)) }}"
 {{- end -}}

--- a/charts/icm-as/tests/newrelic_test.yaml
+++ b/charts/icm-as/tests/newrelic_test.yaml
@@ -153,7 +153,24 @@ tests:
       - matchRegex:
           path: data["newrelic.yml"]
           pattern: ".*(app_name : \"n_a-int_01-icm-standalone\").*"
-  - it: newrelic custom app_name
+  - it: newrelic custom appName
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      newrelic.enabled: true
+      newrelic.appName: icm
+    template: templates/config-newrelic-yaml-cm.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["newrelic.yml"]
+          pattern: ".*(app_name : \"icm\").*"
+  - it: newrelic custom deprecated app_name
     release:
       name: icm-as
     chart:
@@ -163,6 +180,24 @@ tests:
     set:
       newrelic.enabled: true
       newrelic.app_name: icm
+    template: templates/config-newrelic-yaml-cm.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["newrelic.yml"]
+          pattern: ".*(app_name : \"icm\").*"
+  - it: newrelic custom appName with precedence over deprecated app_name
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      newrelic.enabled: true
+      newrelic.app_name: icm-deprecate-name
+      newrelic.appName: icm
     template: templates/config-newrelic-yaml-cm.yaml
     asserts:
       - isKind:

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -79,7 +79,8 @@ newrelic:
   # https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/
   enabled: false
   #   application name (~= environment name): calculated from operationalContext section, set to override
-  # app_name: "icm"
+  # "app_name" deprecated since ICM-AS Helm Charts 1.9.0, will be removed in a future version. Use appName instead.
+  # appName: "icm"
   # provide license key as plain text
   # "license_key" deprecated since ICM-AS Helm Charts 1.8.0, will be removed in a future version.
   # Use licenseKeySecretKeyRef instead.

--- a/charts/icm-replication/values-iste_linux.tmpl
+++ b/charts/icm-replication/values-iste_linux.tmpl
@@ -73,7 +73,7 @@ icm-edit:
         existingClaim: icm-nfs
     newrelic:
       enabled: true
-      app_name: "${HELM_JOB_NAME}-icm-as"
+      appName: "${HELM_JOB_NAME}-icm-as"
       license_key: "${NEWRELIC_LICENSE_KEY}"
 
   icm-web:
@@ -193,7 +193,7 @@ icm-live:
         existingClaim: icm-nfs
     newrelic:
       enabled: true
-      app_name: "${HELM_JOB_NAME}-icm-as"
+      appName: "${HELM_JOB_NAME}-icm-as"
       license_key: "${NEWRELIC_LICENSE_KEY}"
 
   icm-web:

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -70,7 +70,7 @@ icm-as:
       existingClaim: icm-nfs
   newrelic:
     enabled: true
-    app_name: "${HELM_JOB_NAME}-icm-as"
+    appName: "${HELM_JOB_NAME}-icm-as"
     license_key: "${NEWRELIC_LICENSE_KEY}"
 
 icm-web:


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Helm chart value configurations follow camel case, however the key `icm-as.newrelic.app_name` does not.
For consistent naming - also in terms of alignment with the IOM helm charts - we should deprecate (and eventually remove) `app_name` and replace it with `appName`.

## What Is the New Behavior?

`app_name` is deprecated. Provided `appName` instead.

Fixes [AB#94232](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/94232)

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

