### PR TITLE
feat(icm-web): ICM WebAdapter Probes

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -147,6 +147,33 @@ spec:
             value: {{ $value | quote }}
             {{- end }}
           {{- end }}
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.service.httpPort }}
+            # Check every 5s up to a total timeout of 30s
+            initialDelaySeconds: {{ .Values.webadapter.probes.startup.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.webadapter.probes.startup.periodSeconds | default 5 }}
+            failureThreshold: {{ .Values.webadapter.probes.startup.failureThreshold | default 6 }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.httpPort }}
+            # Check every 10s up to a total timeout of 30s
+            initialDelaySeconds: {{ .Values.webadapter.probes.liveness.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.webadapter.probes.liveness.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.webadapter.probes.liveness.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              # /INTERSHOP/wastatus response code is directly linked to configuration servlet availability/validity and
+              # therefore ultimately linked to ICM-AS readiness
+              path: /INTERSHOP/wastatus
+              port: {{ .Values.service.httpPort }}
+              httpHeaders:
+                - name: X-HEALTHCHECK
+                  value: INTERSHOPAGENT
+            # Check every 10s up to a total timeout of 30s
+            initialDelaySeconds: {{ .Values.webadapter.probes.readiness.initialDelaySeconds | default 0 }}
+            periodSeconds: {{ .Values.webadapter.probes.readiness.periodSeconds | default 10 }}
+            failureThreshold: {{ .Values.webadapter.probes.readiness.failureThreshold | default 3 }}
           volumeMounts:
           {{- if .Values.webadapter.customHttpdConfig }}
           - name: httpd-config-volume

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -35,6 +35,20 @@ webadapter:
   replicaCount: 1
   # define the update strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
   updateStrategy: RollingUpdate
+  # Probes, all values are optional, below are the defaults
+  probes:
+    startup: {}
+    #  initialDelaySeconds: 0
+    #  periodSeconds: 5
+    #  failureThreshold: 6
+    liveness: {}
+    #  initialDelaySeconds: 0
+    #  periodSeconds: 10
+    #  failureThreshold: 3
+    readiness: {}
+    #  initialDelaySeconds: 0
+    #  periodSeconds: 10
+    #  failureThreshold: 3
   sslCertificateRetrieval:
     enabled: false
     supportV1: false
@@ -178,7 +192,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # Paths are treated as list of prefixes. Any URL matching one of the prefixes will
-  # be forwared to ICM.
+  # be forwarded to ICM.
   hosts:
     - host: <dns-name-of-service>
       paths:


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

ICM WebAdapter lacks startup/liveness/readiness probes for K8s.
In case of non-liveness or non-readiness of the WebAdapter that can lead to eventually broken deployment states.

Closes [AB#95870](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95870)
Closes [AB#95776](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/95776)

## What Is the New Behavior?

ICM WebAdapter has configurable startup/liveness/readiness probes for K8s.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
