### PR TITLE
docs: improve PWA Helm Chart 0.8.0 migration documentation

### DIFF
--- a/charts/pwa/docs/migrate-to-0.8.0.md
+++ b/charts/pwa/docs/migrate-to-0.8.0.md
@@ -5,7 +5,50 @@
 The `ingress` and `ingresssplit` configurations were combined to only support one `ingress` object that can declare multiple instances.
 We also dropped support for supplying paths because it is not working for the PWA standard deployment.
 
-Old:
+> [!IMPORTANT]
+> When migrating from a previous PWA Helm Chart version to 0.8.0 it is important to remove the existing Ingress object from the cluster beforehand.
+> Because of the differently configured path configuration in the template it cannot be updated but needs to be recreated.
+> Please contact the OPS department for that.
+>
+> This is not relevant for new deployments, only for existing Ingress objects that are migrated.
+
+With this changed `ingress` declaration format a basic `ingress` configuration looks like the following example.
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  instances:
+    ingress:
+      annotations:
+        kubernetes.io/tls-acme: "false"
+      tlsSecretName: tls-star-pwa-intershop-de
+      hosts:
+        - host: pwa.example.local
+```
+A configuration example for the new `ingress` declaration format with host specific `tlsSecretName` overrides is as follows.
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  instances:
+    ingress:
+      annotations:
+        kubernetes.io/tls-acme: "false"
+      tlsSecretName: tls-star-pwa-intershop-de
+      hosts:
+        - host: pwa.example.local
+        - host: store.example.local
+          tlsSecretName: store.tls-star-pwa-intershop-de
+        - host: else.example.local
+          tlsSecretName: else.tls-star-pwa-intershop-de
+```
+
+
+The migration from the previous `ingress` and `ingresssplit` configurations can be seen in the examples below.
+
+__Old__
 
 ```yaml
 ingress:
@@ -43,7 +86,7 @@ ingresssplit:
     - secretName: tls-star-pwa-intershop-de
 ```
 
-New:
+__New__
 
 ```yaml
 ingress:
@@ -74,3 +117,9 @@ ingress:
 Please pay attention to which API version of networking.k8s.io you are using.
 Check [this document](/charts/pwa/docs/migrate-to-0.3.0.md) for differences between the implementations.
 For the sake of chart readability the PWA Helm Chart 0.8.0 only supports the new api-version [networking.k8s.io/v1](http://networking.k8s.io/v1).
+
+## Configurable Update Strategy with default `RollingUpdate`
+
+With the PWA Helm Chart 0.8.0 the `updateStrategy` for the deployments can be changed from the default `RollingUpdate` strategy to the alternative `Recreate` strategy.
+Using `Recreate` better suites the dependency of first updating the SSR container and afterwards updating the NGINX container.
+This might lead to a small downtime but prevents the NGINX from caching outdated SSR results that might lead to 404 errors for no longer existing Javascript files.

--- a/charts/pwa/values.yaml
+++ b/charts/pwa/values.yaml
@@ -20,7 +20,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 upstream:
-  icmBaseURL: https://pwa-ish-demo.test.intershop.com
+  icmBaseURL: https://develop.icm.intershop.de
   ## @param cdnPrefixURL The base URL of your CDN
   ## E.g:
   ## cdnPrefixURL: "https://www.example.com"
@@ -200,6 +200,18 @@ cache:
 ingress:
   enabled: false
   className: nginx
+
+## example for enabled and configured ingress
+# ingress:
+#   enabled: true
+#   className: nginx
+#   instances:
+#     ingress:
+#       annotations:
+#         kubernetes.io/tls-acme: "false"
+#       tlsSecretName: tls-star-pwa-intershop-de
+#       hosts:
+#         - host: pwa.example.local
 
 # Calculated values
 # use with `{{ tpl $.Values.calculated.X.Y $ }}`


### PR DESCRIPTION
## PR Type

[x] Documentation content changes

## What Is the Current Behavior?

The `ingress` declaration format changes in PWA Helm Chart 0.8.0 where not clear enough.

## What Is the New Behavior?

Examples and more documentation was added to address occurring problems with migrating to the new PWA Helm Chart 0.8.0.

## Does this PR Introduce a Breaking Change?
[x] No

## Other Information
