### PR TITLE
fix(icm): do not use weblayer config during e2e tests (#657)

### DIFF
--- a/charts/icm-replication/values-iste_linux.tmpl
+++ b/charts/icm-replication/values-iste_linux.tmpl
@@ -49,8 +49,8 @@ icm-edit:
       SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
       SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
 
-      INTERSHOP_WEBSERVERURL: "http://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:80/"
-      INTERSHOP_WEBSERVERSECUREURL: "https://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:443/"
+      INTERSHOP_WEBSERVERURL: "http://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:80"
+      INTERSHOP_WEBSERVERSECUREURL: "https://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:443"
 
       INTERSHOP_ENCRYPTION_STRICTMODE_ENABLED: "false"
 
@@ -75,16 +75,63 @@ icm-edit:
       appName: "${HELM_JOB_NAME}-icm-as"
       license_key: "${NEWRELIC_LICENSE_KEY}"
 
-    # TODO: move this to values.yaml after weblayer gets standard
-    webLayer:
-      enabled: true
-
+  icm-web:
+    nodeSelector:
+      agentpool: agentpool2
+    resources:
+      agent:
+        limits:
+          memory: 200Mi
+        requests:
+          memory: 200Mi
+    webadapter:
+      podAnnotations:
+        # as long as there is no new cache system we need this annotation for icm-web
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+      image:
+        repository: "${ICM_WEBSERVER_IMAGE}"
+        command: |
+          mkdir -p $HELM_DIRECTORY/server-logs-edit
+          chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs-edit
+          timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+          su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/intershop.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs-edit/wa${timestamp}.log"
+    agent:
+      image:
+        repository: "${ICM_WEBADAPTER_AGENT_IMAGE}"
+        command: |
+          mkdir -p $HELM_DIRECTORY/server-logs-edit
+          chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs-edit
+          timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+          su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/start-waa.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs-edit/waa${timestamp}.log"
+    podSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
+      runAsNonRoot: false
+    environment:
+      HELM_DIRECTORY: "${HELM_DIRECTORY}"
+      SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
+      SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
+    service:
+      httpPort: 8080
+      httpsPort: 8443
+    persistence:
+      pagecache:
+        type: emptyDir
+      customdata:
+        enabled: true
+        existingClaim: icm-nfs
     ingress:
       enabled: true
       className: "ingress-class-${HELM_JOB_NAME}"
       annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: "600m"
         service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        nginx.ingress.kubernetes.io/affinity: cookie
+        nginx.ingress.kubernetes.io/affinity-mode: persistent
+        nginx.ingress.kubernetes.io/session-cookie-name: stid
+        nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+        nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+        nginx.ingress.kubernetes.io/proxy-body-size: "100M"
       hosts:
       - host: "${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}"
         paths:
@@ -94,54 +141,6 @@ icm-edit:
       - secretName: ingress-tls-csi
         hosts:
         - "${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}"
-
-  # TODO: move this to values.yaml after weblayer gets standard
-  icm-web:
-    enabled: false
-
-  ingress-nginx:
-    enabled: true
-    nameOverride: ingress-nginx
-    controller:
-      kind: Deployment
-      ingressClassByName: "true"
-      ingressClassResource:
-        name: "ingress-class-${HELM_JOB_NAME}"
-        controllerValue: "k8s.io/ingress-${HELM_JOB_NAME}"
-      ingressClass: "ingress-class-${HELM_JOB_NAME}"
-      admissionWebhooks:
-        enabled: false
-      nodeSelector:
-        agentpool: agentpool2
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: release
-                operator: In
-                values:
-                - ${HELM_JOB_NAME}-icm-as-edit
-            topologyKey: kubernetes.io/hostname
-      service:
-        external:
-          enabled: "false"
-        internal:
-          enabled: "true"
-          annotations:
-            service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-        externalTrafficPolicy: Local
-      publishService:
-        enabled: "true"
-      config:
-        proxy-read-timeout: "360"
-        proxy-send-timeout: "360"
-        proxy-connect-timeout: "360"
-        disable-access-log: "true"
-      resources:
-        requests:
-          cpu: 200m
-          memory: 300Mi
 
 icm-live:
   icm-as:
@@ -191,8 +190,8 @@ icm-live:
       SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
       SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
 
-      INTERSHOP_WEBSERVERURL: "http://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:80/"
-      INTERSHOP_WEBSERVERSECUREURL: "https://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:443/"
+      INTERSHOP_WEBSERVERURL: "http://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:80"
+      INTERSHOP_WEBSERVERSECUREURL: "https://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:443"
 
       INTERSHOP_ENCRYPTION_STRICTMODE_ENABLED: "false"
 
@@ -218,16 +217,63 @@ icm-live:
       appName: "${HELM_JOB_NAME}-icm-as"
       license_key: "${NEWRELIC_LICENSE_KEY}"
 
-    # TODO: move this to values.yaml after weblayer gets standard
-    webLayer:
-      enabled: true
-
+  icm-web:
+    nodeSelector:
+      agentpool: agentpool2
+    resources:
+      agent:
+        limits:
+          memory: 200Mi
+        requests:
+          memory: 200Mi
+    webadapter:
+      podAnnotations:
+        # as long as there is no new cache system we need this annotation for icm-web
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+      image:
+        repository: "${ICM_WEBSERVER_IMAGE}"
+        command: |
+          mkdir -p $HELM_DIRECTORY/server-logs-live
+          chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs-live
+          timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+          su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/intershop.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs-live/wa${timestamp}.log"
+    agent:
+      image:
+        repository: "${ICM_WEBADAPTER_AGENT_IMAGE}"
+        command: |
+          mkdir -p $HELM_DIRECTORY/server-logs-live
+          chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs-live
+          timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+          su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/start-waa.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs-live/waa${timestamp}.log"
+    podSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
+      runAsNonRoot: false
+    environment:
+      HELM_DIRECTORY: "${HELM_DIRECTORY}"
+      SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
+      SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
+    service:
+      httpPort: 8080
+      httpsPort: 8443
+    persistence:
+      pagecache:
+        type: emptyDir
+      customdata:
+        enabled: true
+        existingClaim: icm-nfs
     ingress:
       enabled: true
       className: "ingress-class-${HELM_JOB_NAME}"
       annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: "600m"
         service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        nginx.ingress.kubernetes.io/affinity: cookie
+        nginx.ingress.kubernetes.io/affinity-mode: persistent
+        nginx.ingress.kubernetes.io/session-cookie-name: stid
+        nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+        nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+        nginx.ingress.kubernetes.io/proxy-body-size: "100M"
       hosts:
       - host: "${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}"
         paths:
@@ -238,9 +284,48 @@ icm-live:
         hosts:
         - "${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}"
 
-  # TODO: move this to values.yaml after weblayer gets standard
-  icm-web:
-    enabled: false
+  ingress-nginx:
+    enabled: true
+    controller:
+      kind: Deployment
+      ingressClassByName: "true"
+      ingressClassResource:
+        name: "ingress-class-${HELM_JOB_NAME}"
+        controllerValue: "k8s.io/ingress-${HELM_JOB_NAME}"
+      ingressClass: "ingress-class-${HELM_JOB_NAME}"
+      admissionWebhooks:
+        enabled: false
+      nodeSelector:
+        agentpool: agentpool2
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: release
+                operator: In
+                values:
+                - ${HELM_JOB_NAME}-icm-web-live
+            topologyKey: kubernetes.io/hostname
+      service:
+        external:
+          enabled: "false"
+        internal:
+          enabled: "true"
+          annotations:
+            service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        externalTrafficPolicy: Local
+      publishService:
+        enabled: "true"
+      config:
+        proxy-read-timeout: "360"
+        proxy-send-timeout: "360"
+        proxy-connect-timeout: "360"
+        disable-access-log: "true"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 300Mi
 
   test:
     enabled: true

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -69,26 +69,68 @@ icm-as:
     customdata:
       enabled: true
       existingClaim: icm-nfs
-  # TODO: move this to values.yaml after weblayer gets standard
-  testConnection:
-    protocol: http
-    port: 80
-    url: /INTERSHOP/web/WFS/SMC
-    serviceSuffix: -icm-as
   newrelic:
     enabled: true
     appName: "${HELM_JOB_NAME}-icm-as"
     license_key: "${NEWRELIC_LICENSE_KEY}"
 
-  # TODO: move this to values.yaml after weblayer gets standard
-  webLayer:
-    enabled: true
+icm-web:
+  nodeSelector:
+    agentpool: agentpool2
+  resources:
+    agent:
+      limits:
+        memory: 200Mi
+      requests:
+        memory: 200Mi
+  webadapter:
+    podAnnotations:
+      # as long as there is no new cache system we need this annotation for icm-web
+      "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+    image:
+      repository: "${ICM_WEBSERVER_IMAGE}"
+      command: |
+        mkdir -p $HELM_DIRECTORY/server-logs
+        chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs
+        timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+        su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/intershop.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs/wa${timestamp}.log"
+  agent:
+    image:
+      repository: "${ICM_WEBADAPTER_AGENT_IMAGE}"
+      command: |
+        mkdir -p $HELM_DIRECTORY/server-logs
+        chown -R ${SERVER_DIRECTORY_USER}:${SERVER_DIRECTORY_GROUP} ${HELM_DIRECTORY}/server-logs
+        timestamp=$(date '+%Y-%m-%d_%H_%M_%S')
+        su ${SERVER_DIRECTORY_USER} -c "/intershop/bin/start-waa.sh 2>&1 | tee outfile $HELM_DIRECTORY/server-logs/waa${timestamp}.log"
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+    runAsNonRoot: false
+  environment:
+    HELM_DIRECTORY: "${HELM_DIRECTORY}"
+    SERVER_DIRECTORY_USER: "${SERVER_DIRECTORY_USER}"
+    SERVER_DIRECTORY_GROUP: "${SERVER_DIRECTORY_GROUP}"
+  service:
+    httpPort: 8080
+    httpsPort: 8443
+  persistence:
+    pagecache:
+      type: emptyDir
+    customdata:
+      enabled: true
+      existingClaim: icm-nfs
   ingress:
     enabled: true
     className: "ingress-class-${HELM_JOB_NAME}"
     annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "600m"
       service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      nginx.ingress.kubernetes.io/affinity: cookie
+      nginx.ingress.kubernetes.io/affinity-mode: persistent
+      nginx.ingress.kubernetes.io/session-cookie-name: stid
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+      nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+      nginx.ingress.kubernetes.io/proxy-body-size: "100M"
     hosts:
     - host: "${HELM_JOB_NAME}.${DNS_ZONE_NAME}"
       paths:
@@ -98,10 +140,6 @@ icm-as:
     - secretName: ingress-tls-csi
       hosts:
       - "${HELM_JOB_NAME}.${DNS_ZONE_NAME}"
-
-# TODO: move this to values.yaml after weblayer gets standard
-icm-web:
-  enabled: false
 
 ingress-nginx:
   enabled: true
@@ -124,7 +162,7 @@ ingress-nginx:
             - key: release
               operator: In
               values:
-              - ${HELM_JOB_NAME}-icm-as
+              - ${HELM_JOB_NAME}-icm-web
           topologyKey: kubernetes.io/hostname
     service:
       external:
@@ -176,8 +214,6 @@ mailhog:
 testrunner:
   nodeSelector:
     agentpool: agentpool2
-  appServerConnection:
-    serviceName: icm-as
   image:
     repository: "${ICM_TEST_IMAGE}"
     command: |


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

End2end tests would use weblayer configuration

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #657

## What Is the New Behavior?

End2end tests wouldn't use weblayer configuration

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

