### PR TITLE
fix(icm-web): Graceful Container Shutdown of WebAdapter and WebAdapterAgent (#97203)

### DIFF
--- a/charts/icm-replication/values.yaml
+++ b/charts/icm-replication/values.yaml
@@ -75,7 +75,7 @@ icm-live:
     agent:
       replicaCount: 1
       image:
-        repository: intershophub/icm-webadapteragent:4.0.0
+        repository: intershophub/icm-webadapteragent:4.0.1
     appServerConnection:
       serviceName: icm-as-live
     persistence:

--- a/charts/icm-replication/values.yaml
+++ b/charts/icm-replication/values.yaml
@@ -70,7 +70,7 @@ icm-live:
     webadapter:
       replicaCount: 1
       image:
-        repository: intershophub/icm-webadapter:2.4.6
+        repository: intershophub/icm-webadapter:2.5.0
         secret: dockerhub
     agent:
       replicaCount: 1

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -79,7 +79,7 @@ agent:
   # in some REST-based environment the webadapteragent isn't mandatory
   enabled: true
   image:
-    repository: intershophub/icm-webadapteragent:4.0.0
+    repository: intershophub/icm-webadapteragent:4.0.1
     pullPolicy: IfNotPresent
     command: |
       /intershop/bin/start-waa.sh

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -82,8 +82,9 @@ agent:
   image:
     repository: intershophub/icm-webadapteragent:4.0.1
     pullPolicy: IfNotPresent
-    command: |
-      /intershop/bin/start-waa.sh
+    # Using exec to replace subshell (/bin/sh -c "...") with the shell script command
+    # Signals will be sent directly to the WAA process of the shell script command, not an intermediate shell process
+    command: exec /intershop/bin/start-waa.sh
   # define the number of replicas beeing deployed (int, > 0, default=1)
   replicaCount: 1
   # define update the strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -23,8 +23,9 @@ webadapter:
   image:
     repository: intershophub/icm-webadapter:2.5.0
     pullPolicy: IfNotPresent
-    command: |
-      /intershop/bin/intershop.sh
+    # Using exec to replace subshell (/bin/sh -c "...") with the shell script command
+    # Signals will be sent directly to the WA process of the shell script command, not an intermediate shell process
+    command: exec /intershop/bin/intershop.sh
   # disable HTTP/2 protocol support if required
   disableHTTP2: false
   customHttpdConfig: false

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -21,7 +21,7 @@ operationalContext:
 
 webadapter:
   image:
-    repository: intershophub/icm-webadapter:2.4.6
+    repository: intershophub/icm-webadapter:2.5.0
     pullPolicy: IfNotPresent
     command: |
       /intershop/bin/intershop.sh

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -85,7 +85,7 @@ icm-web:
     enabled: true
     replicaCount: 1
     image:
-      repository: intershophub/icm-webadapteragent:4.0.0
+      repository: intershophub/icm-webadapteragent:4.0.1
   persistence:
     pagecache:
       type: emptyDir

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -78,7 +78,7 @@ icm-web:
       # as long as there is no new cache system we need this annotation for icm-web
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     image:
-      repository: intershophub/icm-webadapter:2.4.6
+      repository: intershophub/icm-webadapter:2.5.0
       secret: dockerhub
   agent:
     # in some REST-based environment the webadapteragent isn't mandatory


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes


## What Is the Current Behavior?

Both WebAdapter and WebAdapterAgent container are not shutting down gracefully and stay running until the [K8s graceful pod shutdown period](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination) is exceeded.


## What Is the New Behavior?

Both WebAdapter and WebAdapterAgent container are shutting down gracefully now. This also speed-up the deployment deletion process and saves Node resources, as both container are properly removed almost immediately in comparison to before.

The WebAdapter `2.5.0` and WebAdapterAgent `4.0.1` Docker Images contains fixes for the shutdown process on container level. Plus the fixes on icm-web helm chart level for both container commands.

Issue Number:
Fixes [AB#97203](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/97203)
Fixes [AB#96961](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/96961)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
