### PR TITLE
feat(icm-web): Try to schedule WA pods evenly over different nodes

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- if and (not .Values.nodeSelector) (.Values.webadapter.schedulePodsPreferredEvenlyAcrossNodes) }}
       affinity:
         podAntiAffinity:
-          # Chose schedulability over pod anti-affinity preference satisfaction
+          # Choose schedulability over pod anti-affinity preference satisfaction
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -42,6 +42,24 @@ spec:
       nodeSelector:
         {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
       {{- end }}
+      {{- if and (not .Values.nodeSelector) (.Values.webadapter.schedulePodsPreferredEvenlyAcrossNodes) }}
+      affinity:
+        podAntiAffinity:
+          # Chose schedulability over pod anti-affinity preference satisfaction
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              # Spread WA pods evenly over nodes
+              # See ticket #95582 regarding the simultaneous kill at nearly the exact same moment,
+              # likely same node was affected by memory pressure
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ include "icm-web.fullname" . }}-wa
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- range .Values.imagePullSecrets }}

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -72,6 +72,9 @@ webadapter:
     enabled: false
     binding: <name-of-the-binding>
 
+  # define if the scheduler should try to place the replica set of WA pods evenly over different nodes
+  schedulePodsPreferredEvenlyAcrossNodes: true
+
   # define custom labels for deployment and pods:
   deploymentLabels: {}
   podLabels: {}

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -72,7 +72,7 @@ webadapter:
     enabled: false
     binding: <name-of-the-binding>
 
-  # define if the scheduler should try to place the replica set of WA pods evenly over different nodes
+  # define if the scheduler should try to place the ReplicaSet of WA pods evenly over different nodes
   schedulePodsPreferredEvenlyAcrossNodes: true
 
   # define custom labels for deployment and pods:


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [x] Application / infrastructure changes

## What Is the Current Behavior?

According to the default topology constraints a max. skew of 3 node hostnames regarding scheduled WA pods is possible.
https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints



## What Is the New Behavior?

Configuration introduced to try to evenly schedule WA pods across different nodes.

Issue Number:
Fixes [AB#97982](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/97982)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

