### PR TITLE
feat(icm): Provide configurable access by IPs to internal WA pages

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -153,8 +153,17 @@ spec:
           - "-c"
           - {{- toYaml .Values.webadapter.image.command | nindent 12 }}
           env:
+          - name: ENVIRONMENT
+            value: "{{ include "icm-as.environmentName" . }}"
           - name: ICM_ICMSERVLETURLS
             value: "cs.url.0=http://{{ .Release.Name }}-{{ .Values.appServerConnection.serviceName }}:{{ .Values.appServerConnection.port }}/servlet/ConfigurationServlet"
+          # Allow access to internal pages from private address blocks (e.g. within the K8s cluster) according to IANA
+          # or from loopback addresses of the local host container
+          # Can be extended by additional IPs
+          {{- $defaultAllowedIPs := list "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "127.0.0.0/8" }}
+          {{- $additionalAllowedIPs := compact (regexSplit ",\\s*" (.Values.webadapter.accessInternalPagesAllowIPs | default "") -1) }}
+          - name: ICM_WA_ACCESS_INTERNAL_PAGES_ALLOW_IPS
+            value: {{ join "," (concat $defaultAllowedIPs $additionalAllowedIPs) | quote }}
           {{- if .Values.webadapter.disableHTTP2 }}
           - name: ICM_WEBSERVER_DISABLE_HTTP2
             value: "true"

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -32,7 +32,7 @@ webadapter:
   # provides custom certificates for webadapter
   customSSLCertificates: false
   overrideSSL: false
-  # define the number of replicas beeing deployed (int, > 0, default=1)
+  # define the number of replicas being deployed (int, > 0, default=1)
   replicaCount: 1
   # define the update strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
   updateStrategy: RollingUpdate
@@ -61,6 +61,10 @@ webadapter:
       keyvaultName: <name-of-the-KeyVault>
       certificateName: <name-of-the-certificate>
 
+  # define comma-separated list of IPs which are allowed to access internal pages of the webadapter (like wastatistics)
+  # Local network addresses (e.g. from within the K8s cluster) are already permitted by default
+  # accessInternalPagesAllowIPs: "68.0.0.0/8, 10.20.30.40"
+
   # define custom annotations for deployment and pods:
   deploymentAnnotations: {}
   #  myAnnotation: true
@@ -88,7 +92,7 @@ agent:
     # Using exec to replace subshell (/bin/sh -c "...") with the shell script command
     # Signals will be sent directly to the WAA process of the shell script command, not an intermediate shell process
     command: exec /intershop/bin/start-waa.sh
-  # define the number of replicas beeing deployed (int, > 0, default=1)
+  # define the number of replicas being deployed (int, > 0, default=1)
   replicaCount: 1
   # define update the strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
   updateStrategy: RollingUpdate


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

IPs cannot be configured to access internal WA pages.

Issue Number:
Fixes [AB#98005](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/98005)

## What Is the New Behavior?

IPs can be configured to access internal WA pages.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

