### PR TITLE
feat(icm): use logger instead of tee (#716)

### DIFF
--- a/charts/icm-replication/values-iste_linux.tmpl
+++ b/charts/icm-replication/values-iste_linux.tmpl
@@ -389,8 +389,26 @@ icm-live:
         su ${SERVER_DIRECTORY_USER} <<'EOF'
           set -x
           export PATH=$ROOTPATH
-          sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee -a ${RESULT_DIRECTORY}/istestrunner_log.txt
+          logfile=${RESULT_DIRECTORY}/istestrunner_log.txt
+          sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee outfile $logfile &
+          main_pid=$!
+
+          prev_size=0
+          update_modified_date() {
+            while kill -0 $main_pid 2>/dev/null; do
+              sleep 10
+              curr_size=$(stat -c%s "$logfile")
+              if [ "$curr_size" -ne "$prev_size" ]; then
+                touch $logfile
+                sync
+                prev_size=$curr_size
+              fi
+            done
+          }
+          update_modified_date &
+          wait $main_pid
           PROCESS_ERROR_LEVEL=$?
+
           TEST_EXECUTION_RESULT_STATUS="failed"
           if [ "${PROCESS_ERROR_LEVEL}" -eq 0 ];
           then

--- a/charts/icm/values-iste_linux.tmpl
+++ b/charts/icm/values-iste_linux.tmpl
@@ -244,8 +244,26 @@ testrunner:
       su ${SERVER_DIRECTORY_USER} <<'EOF'
         set -x
         export PATH=$ROOTPATH
-        sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee -a ${RESULT_DIRECTORY}/istestrunner_log.txt
+        logfile=${RESULT_DIRECTORY}/istestrunner_log.txt
+        sh /intershop/bin/testrunner.sh -s=${TESTSUITE} -o=${RESULT_DIRECTORY} 2>&1 | tee outfile $logfile &
+        main_pid=$!
+
+        prev_size=0
+        update_modified_date() {
+          while kill -0 $main_pid 2>/dev/null; do
+            sleep 10
+            curr_size=$(stat -c%s "$logfile")
+            if [ "$curr_size" -ne "$prev_size" ]; then
+              touch $logfile
+              sync
+              prev_size=$curr_size
+            fi
+          done
+        }
+        update_modified_date &
+        wait $main_pid
         PROCESS_ERROR_LEVEL=$?
+
         TEST_EXECUTION_RESULT_STATUS="failed"
         if [ "${PROCESS_ERROR_LEVEL}" -eq 0 ];
         then


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] CI-related changes

## What Is the Current Behavior?

Currently we use NFS to store test related data. With the switch to Azure Fileshare with SMB the modified date of files is not updated when changing it. But for a testrun the modified date is needed as the iste-execution-service checks it for recent changes. If the modified date is older than e.g. an hour the test aborts. This would abort well running tests.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #716

## What Is the New Behavior?
As long as the test runs the modified date of the `istestrunner_log.txt` is update via a workaround by checking the file size.


## Does this PR Introduce a Breaking Change?

- [x] No

