### PR TITLE
fix(icm): the jgroups now has its own sc (#751)

### DIFF
--- a/charts/icm-as/templates/cluster-jgroups-pvc.yaml
+++ b/charts/icm-as/templates/cluster-jgroups-pvc.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteMany
   # use the storage class defined by cluster-sc.yaml
   {{- if .Values.persistence.jgroups.cluster.storageClass.create }}
-  storageClassName: "{{ template "icm-as.fullname" . }}-cluster-sites-sc"
+  storageClassName: "{{ template "icm-as.fullname" . }}-cluster-jgroups-sc"
   {{- else if gt (len .Values.persistence.jgroups.cluster.storageClass.existingClass) 0 }}
   storageClassName: {{ .Values.persistence.jgroups.cluster.storageClass.existingClass | quote }}
   {{- end }}

--- a/charts/icm-as/templates/cluster-jgroups-sc.yaml
+++ b/charts/icm-as/templates/cluster-jgroups-sc.yaml
@@ -1,0 +1,16 @@
+{{- if eq .Values.persistence.jgroups.type "cluster" -}}
+{{- if .Values.persistence.jgroups.cluster.storageClass.create -}}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ include "icm-as.fullname" . }}-cluster-jgroups-sc
+provisioner: kubernetes.io/azure-file
+allowVolumeExpansion: true
+mountOptions:
+{{- range .Values.persistence.jgroups.cluster.storageClass.mountOptions }}
+- {{ . }}
+{{- end }}
+parameters:
+  skuName: {{ .Values.persistence.jgroups.cluster.storageClass.skuName }}
+{{- end -}}
+{{- end -}}

--- a/charts/icm-as/tests/persistence-jgroups_test.yaml
+++ b/charts/icm-as/tests/persistence-jgroups_test.yaml
@@ -1,6 +1,8 @@
 suite: tests correctness of persistence.jgroups section
 templates:
   - templates/as-deployment.yaml
+  - templates/cluster-jgroups-sc.yaml
+  - templates/cluster-jgroups-pvc.yaml
 tests:
   - it: type=emptyDir in as-deployment
     release:
@@ -61,6 +63,86 @@ tests:
             name: jgroups-volume
             persistentVolumeClaim:
               claimName: "custom-claim"
+
+  - it: type=use existing sc in cluster-jgroups-pvc
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      persistence.jgroups.type: cluster
+      persistence.jgroups.cluster.storageClass.create: false
+      persistence.jgroups.cluster.storageClass.existingClass: "custom-storage-class-name"
+    template: templates/cluster-jgroups-pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: "icm-as-cluster-jgroups-pvc"
+      - equal:
+          path: spec.storageClassName
+          value: "custom-storage-class-name"
+
+  - it: type=create cluster-jgroups-sc
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      persistence.jgroups.type: cluster
+      persistence.jgroups.cluster.storageClass.create: true
+      persistence.jgroups.cluster.storageClass.existingClass: ""
+      persistence.jgroups.cluster.storageClass.skuName: Standard_LRS
+      persistence.jgroups.cluster.storageClass.mountOptions:
+      - uid=150
+      - gid=150
+      - dir_mode=0777
+      - file_mode=0777
+      - mfsymlinks
+      - cache=strict
+      - actimeo=30
+    template: templates/cluster-jgroups-sc.yaml
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: "icm-as-cluster-jgroups-sc"
+      - equal:
+          path: provisioner
+          value: kubernetes.io/azure-file
+      - equal:
+          path: allowVolumeExpansion
+          value: true
+      - equal:
+          path: mountOptions[0]
+          value: uid=150
+      - equal:
+          path: mountOptions[1]
+          value: gid=150
+      - equal:
+          path: mountOptions[2]
+          value: dir_mode=0777
+      - equal:
+          path: mountOptions[3]
+          value: file_mode=0777
+      - equal:
+          path: mountOptions[4]
+          value: mfsymlinks
+      - equal:
+          path: mountOptions[5]
+          value: cache=strict
+      - equal:
+          path: mountOptions[6]
+          value: actimeo=30
+      - equal:
+          path: parameters.skuName
+          value: Standard_LRS
 
   - it: type=azureFiles in as-deployment
     release:


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

own configured jgroups StorageClass is missing. Instead the sites-sc is used.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #751

## What Is the New Behavior?

own jgroups persistence storageClass enabled

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

