### PR TITLE
feat(icm): Configurable access to internal WA endpoints

### DIFF
--- a/charts/icm-web/templates/ingress.yaml
+++ b/charts/icm-web/templates/ingress.yaml
@@ -42,4 +42,51 @@ spec:
                   name: http
           {{- end }}
     {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-internal-pages-only
+  labels:
+    app.kubernetes.io/name: {{ $fullName }} # Use shared name for the name label of the icm-web ingresses
+    helm.sh/chart: {{ include "icm-web.chart" . }}
+    app.kubernetes.io/instance: {{ $fullName }}-internal-pages-only # unique ingress identifier
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    nginx.ingress.kubernetes.io/real-ip-header: "X-Forwarded-For"
+    # Allow access to internal pages from Intershop network addresses and from loopback addresses of the local host container
+    # Can be extended by additional IPs
+    {{- $defaultAllowedIPs := list "127.0.0.0/8,195.110.61.246" }}
+    {{- $additionalAllowedIPs := compact (.Values.ingress.accessInternalWebAdapterPagesAllowIPs | default (list "")) }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ join "," (concat $defaultAllowedIPs $additionalAllowedIPs) | quote }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /INTERSHOP/wastatistics
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}-wa
+                port:
+                  name: http
+    {{- end }}
 {{- end }}

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -207,6 +207,10 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # define list of IPs which are allowed to access internal pages of the webadapter service (e.g. "wastatistics")
+  # Intershop network addresses and loopback addresses of the local host container are already permitted by default
+  # accessInternalWebAdapterPagesAllowIPs:
+  # - 10.0.0.0/8
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -32,7 +32,7 @@ webadapter:
   # provides custom certificates for webadapter
   customSSLCertificates: false
   overrideSSL: false
-  # define the number of replicas beeing deployed (int, > 0, default=1)
+  # define the number of replicas being deployed (int, > 0, default=1)
   replicaCount: 1
   # define the update strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
   updateStrategy: RollingUpdate
@@ -88,7 +88,7 @@ agent:
     # Using exec to replace subshell (/bin/sh -c "...") with the shell script command
     # Signals will be sent directly to the WAA process of the shell script command, not an intermediate shell process
     command: exec /intershop/bin/start-waa.sh
-  # define the number of replicas beeing deployed (int, > 0, default=1)
+  # define the number of replicas being deployed (int, > 0, default=1)
   replicaCount: 1
   # define update the strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
   updateStrategy: RollingUpdate


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Access to internal WA endpoints permitted per default and no configuration available to allow IPs to access those endpoints.

Issue Number:
Fixes [AB#98249](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/98249)

## What Is the New Behavior?

Access to internal WA endpoints denied per default and configuration available to allow IPs to access those endpoints.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

