### PR TITLE
feat(icm): allow shutdown via replicas=0 definition (#787)

### DIFF
--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -17,17 +17,19 @@ metadata:
     app: {{ include "icm-as.fullname" .}}
 spec:
   progressDeadlineSeconds: 600
-  replicas: {{ .Values.replicaCount | default 1 }}
+  replicas: {{ .Values.replicaCount | default 0 }}
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: icm-as
       release: {{ include "icm-as.fullname" . }}
+  {{- if (ne (.Values.replicaCount | default 0) 0) }}
   strategy:
     type: {{ .Values.updateStrategy | default "RollingUpdate" }}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  {{- end }}
   template:
     metadata:
       {{- include "icm-as.podData" . | nindent 6 }}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     matchLabels:
       app: icm-as
       release: {{ include "icm-as.fullname" . }}
-  {{- if (ne (.Values.replicaCount | default 0) 0) }}
+  {{- if (ne (int .Values.replicaCount) 0) }}
   strategy:
     type: {{ .Values.updateStrategy | default "RollingUpdate" }}
     rollingUpdate:

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.webadapter.replicaCount | default 0 }}
-  {{- if (ne (.Values.webadapter.replicaCount | default 0) 0) }}
+  {{- if (ne (int .Values.webadapter.replicaCount) 0) }}
   strategy:
     type: {{ .Values.webadapter.updateStrategy | default "RollingUpdate" }}
     rollingUpdate:

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -15,9 +15,14 @@ metadata:
       {{- toYaml .Values.webadapter.deploymentLabels | trim | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.webadapter.replicaCount | default 1 }}
+  replicas: {{ .Values.webadapter.replicaCount | default 0 }}
+  {{- if (ne (.Values.webadapter.replicaCount | default 0) 0) }}
   strategy:
     type: {{ .Values.webadapter.updateStrategy | default "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  {{- end }}
   selector:
     matchLabels:
       app: icm-wa

--- a/charts/icm-web/templates/waa-deployment.yaml
+++ b/charts/icm-web/templates/waa-deployment.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.agent.replicaCount | default 0 }}
-  {{- if (ne (.Values.agent.replicaCount | default 0) 0) }}
+  {{- if (ne (int .Values.agent.replicaCount) 0) }}
   strategy:
     type: {{ .Values.agent.updateStrategy | default "RollingUpdate" }}
     rollingUpdate:

--- a/charts/icm-web/templates/waa-deployment.yaml
+++ b/charts/icm-web/templates/waa-deployment.yaml
@@ -16,9 +16,14 @@ metadata:
       {{- toYaml .Values.agent.deploymentLabels | trim | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.agent.replicaCount | default 1 }}
+  replicas: {{ .Values.agent.replicaCount | default 0 }}
+  {{- if (ne (.Values.agent.replicaCount | default 0) 0) }}
   strategy:
     type: {{ .Values.agent.updateStrategy | default "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  {{- end }}
   selector:
     matchLabels:
       app: icm-waa


### PR DESCRIPTION
ADO working item (#97788)

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->
It' a minor change, because without the environment can't shutdown the servers. (and keep the infrastructure)

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

Defining replicaCount=0 doesn't lead to a total shutdown, because the default value=1 overrules that definition.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #787

## What Is the New Behavior?

default value in templates is set to 0 (doesn't overrule) values.yaml still defines 1 as default.
definition of replicateCount=0 also disables the updateStategy and maxSure.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information
