### PR TITLE
feat(icm): New replication environment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ environment/tmp_repo/**
 build/**
 .idea/
 .project
+.debug
 **/tests/__snapshot__
 **/tests/__results__
 values-*.yaml

--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -85,14 +85,7 @@ env:
   value: "{{ .Values.database.jdbcPassword }}"
 {{- end }}
 {{- end }}
-{{- if .Values.replication.enabled }}
-- name: STAGING_SYSTEM_TYPE
-  {{- if eq .Values.replication.role "source" }}
-  value: editing
-  {{- else }}
-  value: live
-  {{- end }}
-{{- end }}
+{{ include "icm-as.envReplication" . }}
 {{ include "icm-as.featuredJVMArguments" . }}
 {{ include "icm-as.additionalJVMArguments" . }}
 {{- range $key, $value := .Values.environment }}
@@ -132,6 +125,74 @@ Creates the environment secrets section
     secretKeyRef:
       name: {{ $secret.name | quote }}
       key: {{ $secret.key | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Creates the environment replication section
+*/}}
+{{- define "icm-as.envReplication" -}}
+{{- if .Values.replication.enabled }}
+- name: STAGING_SYSTEM_TYPE
+  {{- if eq .Values.replication.role "source" }}
+  value: editing
+  {{- else }}
+  value: live
+  {{- end }}
+{{/*
+ICM-AS >= 12.2.0 supports new replication configuration via environments instead of replication-clusters.xml
+ICM-AS >= 13.0.0 requires new replication configuration
+*/}}
+{{- $icmApplicationServerImageSemanticVersion := include "icm-as.imageSemanticVersion" . -}}
+{{- $hasIcmApplicationServerImageSemanticVersion := regexMatch "([0-9]+)\\.([0-9]+)\\.([0-9]+)" $icmApplicationServerImageSemanticVersion -}}
+{{- $hasNewReplicationConfigurationRequirement := and ($hasIcmApplicationServerImageSemanticVersion) (semverCompare ">= 13.0.0" $icmApplicationServerImageSemanticVersion) -}}
+{{- $hasNewReplicationConfigurationSupport := and ($hasIcmApplicationServerImageSemanticVersion) (semverCompare ">= 12.2.0" $icmApplicationServerImageSemanticVersion) -}}
+{{- $hasNewReplicationConfiguration := or (hasKey .Values.replication "source") (hasKey .Values.replication "targets") -}}
+{{- if and ($hasNewReplicationConfigurationRequirement) (not $hasNewReplicationConfiguration) -}}
+  {{- fail (printf "Error: Since ICM-AS 13.0.0 you need to use the new 'replication.source'/'replication.targets' configuration for replication, currently used '%s'." $icmApplicationServerImageSemanticVersion) -}}
+{{- end -}}
+{{- if and ($hasIcmApplicationServerImageSemanticVersion) (not $hasNewReplicationConfigurationSupport) ($hasNewReplicationConfiguration) -}}
+  {{- fail (printf "Error: The new replication configuration 'replication.source'/'replication.targets' can be only used with ICM-AS 12.2.0 and newer, currently used '%s'." $icmApplicationServerImageSemanticVersion) -}}
+{{- end -}}
+{{- if and ($hasNewReplicationConfiguration) (hasKey .Values.replication.source "databaseLink") (hasKey .Values.replication.source "databaseName") -}}
+  {{- fail "Error: Either mutual exclusive 'replication.source.databaseUser' or 'replication.source.databaseLink' have to be configured, but not both." -}}
+{{- end -}}
+{{- if and (or (not $hasIcmApplicationServerImageSemanticVersion) $hasNewReplicationConfigurationSupport) $hasNewReplicationConfiguration }}
+{{- $replicationSystemIDs := keys .Values.replication.targets | sortAlpha -}}
+- name: STAGING_SYSTEMS_IDS
+  value: {{ join "," $replicationSystemIDs | quote }}
+{{- range $index, $replicationSystemID := $replicationSystemIDs }}
+{{- if regexMatch ".*[._-].*" $replicationSystemID -}}
+  {{- fail (printf "Error: The key '%s' in 'replication.targets' violates the constraint that it cannot contain any of these characters: '.', '-', '_'." $replicationSystemID) }}
+{{- end -}}
+{{- $replicationTarget := get $.Values.replication.targets $replicationSystemID -}}
+{{- $replicationSystemIDEnvironmentKeyPrefix := printf "STAGING_SYSTEMS_%s" ($replicationSystemID | upper) }}
+{{- if $.Values.replication.source.webserverUrl }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_SOURCE_BASEURL
+  value: {{ $.Values.replication.source.webserverUrl | quote }}
+{{- end }}
+{{- if $.Values.replication.source.databaseUser }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_SOURCE_DATABASEUSER
+  value: {{ $.Values.replication.source.databaseUser | quote }}
+{{- end }}
+{{- if $.Values.replication.source.databaseLink }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_SOURCE_DATABASELINK
+  value: {{ $.Values.replication.source.databaseLink | quote }}
+{{- end }}
+{{- if $.Values.replication.source.databaseName }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_SOURCE_DATABASENAME
+  value: {{ $.Values.replication.source.databaseName | quote }}
+{{- end }}
+{{- if $replicationTarget.webserverUrl }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_TARGET_BASEURL
+  value: {{ $replicationTarget.webserverUrl | quote }}
+{{- end }}
+{{- if $replicationTarget.databaseUser }}
+- name: {{ $replicationSystemIDEnvironmentKeyPrefix }}_TARGET_DATABASEUSER
+  value: {{ $replicationTarget.databaseUser | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Create the name of the service account to use
 
 {{/*
 Create the values for the environment variable FEATURED_JVM_ARGUMENTS.
-These are predefined parameter from serveral features.
+These are predefined parameter from several features.
 */}}
 {{- define "icm-as.featuredJVMArguments" -}}
 {{- $addVmOptions := list -}}
@@ -162,6 +162,17 @@ command: {{- toYaml .Values.customCommand | nindent 2 }}
 {{- end -}}
 
 {{/*
+Image SemVer release
+*/}}
+{{- define "icm-as.imageSemanticVersion" -}}
+  {{- if contains ":" .Values.image.repository -}}
+    {{- splitList ":" .Values.image.repository | last | trim -}}
+  {{- else -}}
+    {{- .Values.image.tag | default .Chart.AppVersion -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 imagePullSecrets spec
 */}}
 {{- define "icm-as.imagePullSecrets" -}}
@@ -198,3 +209,26 @@ The discovery mode of jgroups messaging
 {{- end -}}
 {{- end -}}
 
+{{/*
+Whether replication uses the new configuration
+*/}}
+{{- define "icm-as.replicationUsesNewConfiguration" -}}
+  {{- if .Values.replication.enabled -}}
+    {{- $hasNewReplicationConfiguration := or (hasKey .Values.replication "source") (hasKey .Values.replication "targets") -}}
+    {{- $hasNewReplicationConfiguration -}}
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Whether replications' replication-clusters.xml configuration is used
+*/}}
+{{- define "icm-as.replicationUsesReplicationClustersXmlConfiguration" -}}
+  {{- if .Values.replication.enabled -}}
+    {{- $hasDeprecatedReplicationConfiguration := include "icm-as.replicationUsesNewConfiguration" . | eq "false" -}}
+    {{- and ($hasDeprecatedReplicationConfiguration) (eq .Values.replication.role "source") -}}
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -25,7 +25,8 @@ volumeMounts:
 - mountPath: /intershop/jgroups-share
   name: jgroups-volume
 {{- end }}
-{{- if and (.Values.replication.enabled) (eq .Values.replication.role "source")}}
+{{- $replicationUsesReplicationClustersXmlConfiguration := include "icm-as.replicationUsesReplicationClustersXmlConfiguration" . | eq "true" }}
+{{- if $replicationUsesReplicationClustersXmlConfiguration }}
 - mountPath: /intershop/replication-conf/replication-clusters.xml
   name: replication-volume
   readOnly: true

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -23,7 +23,8 @@ volumes:
 {{- end }}
 {{- include "icm-as.volume" (list . "sites" .Values.persistence.sites .Values.podSecurityContext) }}
 {{- include "icm-as.volume" (list . "encryption" .Values.persistence.encryption .Values.podSecurityContext) }}
-{{- if and (.Values.replication.enabled) (eq .Values.replication.role "source")}}
+{{- $replicationUsesReplicationClustersXmlConfiguration := include "icm-as.replicationUsesReplicationClustersXmlConfiguration" . | eq "true" }}
+{{- if $replicationUsesReplicationClustersXmlConfiguration }}
 - name: replication-volume
   configMap:
     name: {{ template "icm-as.fullname" . }}-replication-clusters-xml

--- a/charts/icm-as/templates/config-replication-clusters-xml-cm.yaml
+++ b/charts/icm-as/templates/config-replication-clusters-xml-cm.yaml
@@ -1,4 +1,5 @@
-{{- if and (.Values.replication.enabled) (eq .Values.replication.role "source")}}
+{{- $replicationUsesReplicationClustersXmlConfiguration := include "icm-as.replicationUsesReplicationClustersXmlConfiguration" . | eq "true" -}}
+{{- if $replicationUsesReplicationClustersXmlConfiguration -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/icm-as/tests/replication_test.yaml
+++ b/charts/icm-as/tests/replication_test.yaml
@@ -37,6 +37,33 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: as-deployment without replication
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: false
+    template: templates/as-deployment.yaml
+    asserts:
+      - notContains:
+          any: true
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEM_TYPE
+      - notContains:
+          any: true
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: replication-volume
+      - notContains:
+          any: true
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
   - it: as-deployment role=source
     release:
       name: icm-as
@@ -70,7 +97,7 @@ tests:
             configMap:
               name: icm-as-replication-clusters-xml
 
-  - it: config-replication-clusters-xml-cm default values
+  - it: config-replication-clusters-xml-cm default values (ICM-AS >= 12.2.0)
     release:
       name: icm-as
     chart:
@@ -82,9 +109,30 @@ tests:
       replication.role: source
       replication.targetSystemUrl: https://icm-web-live-wa:443
       replication.sourceDatabaseName: intershop_edit
+      image:
+        tag: 12.2.0
     template: templates/config-replication-clusters-xml-cm.yaml
     asserts:
       # unfortunatelly the complex content can not be checked
+      - isNotEmpty:
+          path: data["replication-clusters.xml"]
+
+  - it: config-replication-clusters-xml-cm default values (ICM-AS < 12.2.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.sourceDatabaseName: intershop_edit
+      image:
+        tag: 12.1.0
+    template: templates/config-replication-clusters-xml-cm.yaml
+    asserts:
       - isNotEmpty:
           path: data["replication-clusters.xml"]
 
@@ -116,7 +164,7 @@ tests:
           content:
             name: replication-volume
 
-  - it: config-replication-clusters-xml-cm role=target
+  - it: config-replication-clusters-xml-cm role=target (ICM-AS < 12.2.0)
     release:
       name: icm-as
     chart:
@@ -128,8 +176,650 @@ tests:
       replication.role: target
       replication.targetSystemUrl: https://icm-web-live-wa:443
       replication.sourceDatabaseName: intershop_edit
+      image:
+        tag: 11.11.0-LTS
     template: templates/config-replication-clusters-xml-cm.yaml
     asserts:
       - hasDocuments:
           count: 0
 
+  - it: config-replication-clusters-xml-cm role=target (ICM-AS >= 12.2.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: target
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.sourceDatabaseName: intershop_edit
+      image:
+        tag: 12.2.0
+    template: templates/config-replication-clusters-xml-cm.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: as-deployment new replication configuration (ICM-AS >= 12.2.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 12.2.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+            value: "icm_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration (ICM-AS >= 12.2.0 with version tag in repository)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        repository: intershophub/icm-as:12.2.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+            value: "icm_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration (ICM-AS >= 13.0.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+            value: "icm_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration (ICM-AS uses non semantic version)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: LOCAL
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+            value: "icm_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration with multiple targets (role = source)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+        live2:
+          webserverUrl: https://icm-web-stage-wa:443
+          databaseUser: repl_user_stage
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1,live2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_TARGET_BASEURL
+            value: "https://icm-web-stage-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_TARGET_DATABASEUSER
+            value: "repl_user_stage"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration with multiple targets (role = target)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: target
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+        live2:
+          webserverUrl: https://icm-web-stage-wa:443
+          databaseUser: repl_user_stage
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1,live2"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_TARGET_BASEURL
+            value: "https://icm-web-stage-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE2_TARGET_DATABASEUSER
+            value: "repl_user_stage"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment new replication configuration with databaseLink
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseLink: edit_db_link
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASELINK
+            value: "edit_db_link"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment with new and old replication configuration
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.sourceDatabaseName: other_database_name
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 12.2.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_IDS
+            value: "live1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_BASEURL
+            value: "https://icm-web-edit-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASEUSER
+            value: "repl_user_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_SOURCE_DATABASENAME
+            value: "icm_edit"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_BASEURL
+            value: "https://icm-web-live-wa:443"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_SYSTEMS_LIVE1_TARGET_DATABASEUSER
+            value: "repl_user_live"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /intershop/replication-conf/replication-clusters.xml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: replication-volume
+
+  - it: as-deployment with new and old null-ed replication configuration
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.sourceDatabaseName: null
+      replication.targetSystemUrl: null
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 12.2.0
+    template: templates/config-replication-clusters-xml-cm.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: as-deployment fails with old replication configuration (ICM-AS >= 13.0.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.sourceDatabaseName: icm_edit
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: Since ICM-AS 13.0.0 you need to use the new 'replication.source'/'replication.targets' configuration for replication, currently used '13.0.0'."
+
+  - it: as-deployment fails with new replication configuration (ICM-AS < 12.2.0)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 12.1.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: The new replication configuration 'replication.source'/'replication.targets' can be only used with ICM-AS 12.2.0 and newer, currently used '12.1.0'."
+
+  - it: as-deployment fails with both databaseLink and databaseName
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseLink: edit_db_link
+        databaseName: icm_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: Either mutual exclusive 'replication.source.databaseUser' or 'replication.source.databaseLink' have to be configured, but not both."
+
+  - it: as-deployment fails with invalid replication target key
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+      replication.targets:
+        live-system:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 13.0.0
+    template: templates/as-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: The key 'live-system' in 'replication.targets' violates the constraint that it cannot contain any of these characters: '.', '-', '_'."

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -440,12 +440,41 @@ replication:
   # defines the type of this replication system (source | target)
   role: <source|target>
 
+  # "targetSystemUrl" deprecated since ICM-AS Helm Charts 2.2.0, will be removed in a future version.
+  # Configure the source and targets within replication instead.
   # if role=source the following properties are mandatory (otherwise they are ignored)
   # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
   targetSystemUrl: <externalUrl>
 
+  # "sourceDatabaseName" deprecated since ICM-AS Helm Charts 2.2.0, will be removed in a future version.
+  # Configure the source and targets within replication instead.
   # the name of the (source) database to be used at the target-system to read data from e.g. intershop_edit
   sourceDatabaseName: <databaseName>
+
+  # The following "source" and "targets" configuration blocks take precedence over
+  # the deprecated "targetSystemUrl" / "sourceDatabaseName" configurations
+  # Configuration for source system that participates in replication
+  # source:
+    # the external URL of the webServer/proxy/ingress e.g. https://icm-web-edit-wa:443
+    # webserverUrl: <sourceExternalUrl>
+    # either mutual exclusive databaseUser or databaseLink have to be configured
+    # databaseLink: <sourceDatabaseLink>
+    # databaseUser: <sourceDatabaseUser>
+    # databaseName: <sourceDatabaseName>
+
+  # Configuration for all target systems that participates in replication
+  # targets:
+    # create multiple target systems - please avoid characters like '.', '-' or '_' in the chosen name/key
+    # live1:
+      # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+      # webserverUrl: <targetExternalUrl>
+      # this database user will be granted access to the database schema of the source replication system
+      # databaseUser: <targetDatabaseUser>
+    # live2:
+      # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+      # webserverUrl: <targetExternalUrl>
+      # this database user will be granted access to the database schema of the source replication system
+      # databaseUser: <targetDatabaseUser>
 
 # Configuration of messaging via jgroups
 jgroups:
@@ -459,7 +488,7 @@ jgroups:
   discovery: file_ping
 
   # extra attributes to be added at the ping-section in xml,
-  # e.g. "readTimeout=\"1000\" operationAttempts=\"5\""
+  # e.g. 'readTimeout="1000" operationAttempts="5"'
   # discoveryExtraAttributes: <extra-attributes>
 
   # the DNS-query. Used with discovery type dns_ping

--- a/charts/icm-replication/values-iste_linux.tmpl
+++ b/charts/icm-replication/values-iste_linux.tmpl
@@ -6,8 +6,14 @@ icm-edit:
       # as long as there are no long running job pods we need this annotation for icm-as
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     replication:
-      targetSystemUrl: https://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:443
-      sourceDatabaseName: "${DATABASE_USER_EDIT}"
+      source:
+        webserverUrl: "https://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:443"
+        databaseUser: "${DATABASE_USER_EDIT}"
+        databaseName: "${DATABASE_USER_EDIT}"
+      targets:
+        live1:
+          webserverUrl: "https://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:443"
+          databaseUser: "${DATABASE_USER_LIVE}"
     image:
       repository: "${ICM_TEST_IMAGE}"
     customCommand:
@@ -141,6 +147,15 @@ icm-live:
     podAnnotations:
       # as long as there are no long running job pods we need this annotation for icm-as
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+    replication:
+      source:
+        webserverUrl: "https://${HELM_JOB_NAME}-edit.${DNS_ZONE_NAME}:443"
+        databaseUser: "${DATABASE_USER_EDIT}"
+        databaseName: "${DATABASE_USER_EDIT}"
+      targets:
+        live1:
+          webserverUrl: "https://${HELM_JOB_NAME}-live.${DNS_ZONE_NAME}:443"
+          databaseUser: "${DATABASE_USER_LIVE}"
     image:
       repository: "${ICM_TEST_IMAGE}"
     customCommand:

--- a/charts/icm-replication/values.yaml
+++ b/charts/icm-replication/values.yaml
@@ -4,8 +4,24 @@ icm-edit:
     replication:
       enabled: true
       role: source
+      # "targetSystemUrl" deprecated since ICM-Replication Helm Charts 2.6.0, will be removed in a future version.
+      # Configure the source and targets within replication instead.
       targetSystemUrl: https://<domain for icm-replication-ingress-nginx-live>:443
+      # "sourceDatabaseName" deprecated since ICM-Replication Helm Charts 2.6.0, will be removed in a future version.
+      # Configure the source and targets within replication instead.
       sourceDatabaseName: intershop_edit
+      # source:
+        # webserverUrl: <sourceExternalUrl>
+        # databaseLink: <sourceDatabaseLink>
+        # databaseUser: <sourceDatabaseUser>
+        # databaseName: <sourceDatabaseName>
+      # targets:
+        # live1:
+          # webserverUrl: <targetExternalUrl>
+          # databaseUser: <targetDatabaseUser>
+        # live2:
+          # webserverUrl: <targetExternalUrl>
+          # databaseUser: <targetDatabaseUser>
     database:
       jdbcURL: "jdbc:sqlserver://<ipaddress or hostname>:1433;databaseName=intershop_edit"
       jdbcUser: "intershop_edit"
@@ -42,6 +58,18 @@ icm-live:
     replication:
       enabled: true
       role: target
+      # source:
+        # webserverUrl: <sourceExternalUrl>
+        # databaseLink: <sourceDatabaseLink>
+        # databaseUser: <sourceDatabaseUser>
+        # databaseName: <sourceDatabaseName>
+      # targets:
+        # live1:
+          # webserverUrl: <targetExternalUrl>
+          # databaseUser: <targetDatabaseUser>
+        # live2:
+          # webserverUrl: <targetExternalUrl>
+          # databaseUser: <targetDatabaseUser>
     database:
       jdbcURL: "jdbc:sqlserver://<ipaddress or hostname>:1433;databaseName=intershop_live"
       jdbcUser: "intershop_live"

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -21,7 +21,7 @@ icm-as:
   - "dockerhub"
   replicaCount: 1
 
-  ## @param environment - extra environment variables to be set on containers
+  # environment variables to be propagated to the icm-as-container
   environment:
 
   ## @param persistence - Either choose local (default), cluster, azurefiles, static or nfs persitence layer
@@ -61,12 +61,41 @@ icm-as:
     # defines the type of this replication system (source | target)
     role: <source|target>
 
+    # "targetSystemUrl" deprecated since ICM Helm Charts 2.6.0, will be removed in a future version.
+    # Configure the source and targets within replication instead.
     # if role=source the following properties are mandatory (otherwise they are ignored)
     # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
     targetSystemUrl: <externalUrl>
 
+    # "sourceDatabaseName" deprecated since ICM Helm Charts 2.6.0, will be removed in a future version.
+    # Configure the source and targets within replication instead.
     # the name of the (source) database to be used at the target-system to read data from e.g. intershop_edit
     sourceDatabaseName: <databaseName>
+
+    # The following "source" and "targets" configuration blocks take precedence over
+    # the deprecated "targetSystemUrl" / "sourceDatabaseName" configurations
+    # Configuration for source system that participates in replication
+    # source:
+      # the external URL of the webServer/proxy/ingress e.g. https://icm-web-edit-wa:443
+      # webserverUrl: <sourceExternalUrl>
+      # either mutual exclusive databaseUser or databaseLink have to be configured
+      # databaseLink: <sourceDatabaseLink>
+      # databaseUser: <sourceDatabaseUser>
+      # databaseName: <sourceDatabaseName>
+
+    # Configuration for all target systems that participates in replication
+    # targets:
+      # create multiple target systems - please avoid characters like '.', '-' or '_' in the chosen name/key
+      # live1:
+        # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+        # webserverUrl: <targetExternalUrl>
+        # this database user will be granted access to the database schema of the source replication system
+        # databaseUser: <targetDatabaseUser>
+      # live2:
+        # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+        # webserverUrl: <targetExternalUrl>
+        # this database user will be granted access to the database schema of the source replication system
+        # databaseUser: <targetDatabaseUser>
 
 icm-web:
   enabled: true


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Helm Charts `icm-replication` (respectively also its "super charts" `icm-as` / `icm`) make use of the replication environment configuration via `replication-cluster.xml`.

Issue Number: Closes #802 / [AB#99130](https://dev.azure.com/intershop-com/cefd1005-00a7-4c79-927f-a16947d1b2e6/_workitems/edit/99130)

## What Is the New Behavior?

Helm Charts `icm-replication` (respectively also its "super charts" `icm-as` / `icm`) make use of the replication environment configuration via succeeding configurations in the `icm/values.yaml` / `icm-as/values.yaml` / `icm-replication/values.yaml`.

The former XML based `replication-cluster.xml` can still be used by applying the deprecated values `replication.targetSystemUrl` / `replication.sourceDatabaseName`, but it is not recommended. Instead, make use of the new values `replication.source` / `replication.targets` (see e.g. `icm/values.yaml` for additional migration information). Using the new values also avoid the need for an extra volume / ConfigMap specifically for replication.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
