### PR TITLE
815 - support infrastructure probing container

### DIFF
--- a/.github/workflows/lint-test_icm-as-integrationtest.yml
+++ b/.github/workflows/lint-test_icm-as-integrationtest.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Run chart-testing (install)
       if: steps.list-changed.outputs.changed == 'true'
       run: |
+        uname -a
         set -x
         random_value=`tr -dc 'a-z0-9' < /dev/urandom | head -c10`
         export NAMESPACE=ct-icm-as-$random_value
@@ -56,7 +57,7 @@ jobs:
 
         sudo mkdir -p /data/icm/sites
         sed -i 's/<local sites folder>/\/data\/icm\/sites/' charts/icm-as/values.yaml
-        
+
         sudo mkdir -p /data/icm/encryption
         sed -i 's/<local encryption folder>/\/data\/icm\/encryption/' charts/icm-as/values.yaml
 

--- a/.github/workflows/lint-test_icm-as-integrationtest.yml
+++ b/.github/workflows/lint-test_icm-as-integrationtest.yml
@@ -41,7 +41,6 @@ jobs:
     - name: Run chart-testing (install)
       if: steps.list-changed.outputs.changed == 'true'
       run: |
-        uname -a
         set -x
         random_value=`tr -dc 'a-z0-9' < /dev/urandom | head -c10`
         export NAMESPACE=ct-icm-as-$random_value

--- a/charts/icm-as/templates/_infrastructureMonitoring.tpl
+++ b/charts/icm-as/templates/_infrastructureMonitoring.tpl
@@ -1,0 +1,87 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Creates init-containers
+*/}}
+{{- define "icm-as.infrastructureMonitoringContainer" -}}
+{{- if .Values.infrastructureMonitoring.enabled }}
+- name: infrastructure-monitoring
+  image: {{ .Values.infrastructureMonitoring.image.repository }}
+  imagePullPolicy: {{ .Values.infrastructureMonitoring.image.pullPolicy | default "IfNotPresent" }}
+  env:
+  {{- if .Values.mssql.enabled }}
+  - name: QUARKUS_DATASOURCE_JDBC_URL
+    value: {{ printf "jdbc:sqlserver://%s-mssql-service:1433;database=%s;TrustServerCertificate=True;" (include "icm-as.fullname" .) .Values.mssql.databaseName }}
+  - name: QUARKUS_DATASOURCE_USERNAME
+    value: "{{ .Values.mssql.user }}"
+{{ include "icm-as.envDatabasePassword" (list "QUARKUS_DATASOURCE_PASSWORD" .Values.mssql.passwordSecretKeyRef .Values.mssql.password) | indent 2 }}
+  {{- else }}
+  - name: QUARKUS_DATASOURCE_JDBC_URL
+    {{ if regexMatch ".+;$" .Values.database.jdbcURL -}}
+    value: "{{ .Values.database.jdbcURL }}TrustServerCertificate=True;"
+    {{- else -}}
+    value: "{{ .Values.database.jdbcURL }};TrustServerCertificate=True;"
+    {{- end }}
+  - name: QUARKUS_DATASOURCE_USERNAME
+    value: "{{ .Values.database.jdbcUser }}"
+{{ include "icm-as.envDatabasePassword" (list "QUARKUS_DATASOURCE_PASSWORD" .Values.database.jdbcPasswordSecretKeyRef .Values.database.jdbcPassword) | indent 2 }}
+  {{- end }}
+  - name: JAVA_OPTS_APPEND
+    value: "{{- include "icm-as.infrastructureMonitoringContainer.probeOpts" (set .Values.infrastructureMonitoring.databaseLatency "probeName" "databaseLatency") }}"
+  ports:
+  - name: inframonitoring
+    containerPort: 8080
+    protocol: TCP
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+{{ include "icm-as.infrastructureMonitoringContainer.k8sProbe" (list "started" 3 30 5) }}
+{{ include "icm-as.infrastructureMonitoringContainer.k8sProbe" (list "live" 3 10 5) }}
+{{ include "icm-as.infrastructureMonitoringContainer.k8sProbe" (list "ready" 3 10 5) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+creates a K8s probe configuration (startup, liveness, readiness)
+expecting to get called like:
+{{ include "icm-as.infrastructureMonitoringContainer.k8sProbe" (list "<type>" <failureThreshold> <initialDelaySeconds> <periodSeconds>) }}
+with
+  <type>: one of [started, live, ready]
+  <failureThreshold>: failure threshold (count)
+  <initialDelaySeconds>: initial delay (seconds)
+  <periodSeconds>: period (seconds)
+*/}}
+{{- define "icm-as.infrastructureMonitoringContainer.k8sProbe" -}}
+{{- $type := index . 0 }}
+{{- $failureThreshold := index . 1 }}
+{{- $initialDelaySeconds := index . 2 }}
+{{- $periodSeconds := index . 3 }}
+{{- if eq $type "started" }}
+  startupProbe:
+{{- else if eq $type "live" }}
+  livenessProbe:
+{{- else }}
+  readinessProbe:
+{{- end }}
+    httpGet:
+      path: /q/health/{{ $type }}
+      port: inframonitoring
+    failureThreshold: {{ $failureThreshold }}
+    initialDelaySeconds: {{ $initialDelaySeconds }}
+    periodSeconds: {{ $periodSeconds }}
+{{- end -}}
+
+{{/*
+creates an infrastructure probe configuration
+expecting to get called like:
+  - name: JAVA_OPTS_APPEND
+    value: {{- include "icm-as.infrastructureMonitoringContainer.probeOpts" (set .Values.infrastructureMonitoring.databaseLatency "probeName" "databaseLatency") | indent 1 }}
+replace:  '.Values.infrastructureMonitoring.databaseLatency' by the probe's values
+          "databaseLatency" by the probe's name
+*/}}
+{{- define "icm-as.infrastructureMonitoringContainer.probeOpts" -}}
+{{- printf "-Dprobes.%s.enabled=%t -Dprobes.%s.interval=%s" .probeName .enabled .probeName .interval -}}
+{{- end -}}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -65,6 +65,7 @@ spec:
         {{- include "icm-as.volumeMounts" . | nindent 8 }}
         {{- include "icm-as.probes" . | nindent 8 }}
         {{- include "icm-as.lifecycle" . | nindent 8 }}
+      {{- include "icm-as.infrastructureMonitoringContainer" . | nindent 6 }}
       {{- include "icm-as.initContainers" . | nindent 6 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/icm-as/templates/infrastructure-monitoring-service.yaml
+++ b/charts/icm-as/templates/infrastructure-monitoring-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.infrastructureMonitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "icm-as.fullname" . }}-inframonitoring
+  labels:
+    app: {{ include "icm-as.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    prometheus.io/path: /q/metrics
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8080'
+spec:
+  ports:
+  - name: inframonitoring
+    port: 8080
+    targetPort: inframonitoring
+  selector:
+    app: icm-as
+    release: {{ include "icm-as.fullname" . }}
+status:
+  loadBalancer: {}
+{{- end }}

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -11,6 +11,8 @@ tests:
       appVersion: 11.0.1
     values:
       - ../values.yaml
+    set:
+      infrastructureMonitoring.enabled: true
     template: templates/as-deployment.yaml
     asserts:
       - isKind:

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -60,7 +60,7 @@ tests:
       - equal:
           path: spec.template.metadata.labels.app
           value: icm-as
-      #spec.template.spec.containers
+      #spec.template.spec.containers[0]
       - equal:
           path: spec.template.spec.containers[0].name
           value: icm-as-server
@@ -148,6 +148,57 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.httpGet.path
           value: /status/action/shutdown
+      #spec.template.spec.containers[1]
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: infrastructure-monitoring
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: intershophub/infrastructure-probing:1.0.0
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: IfNotPresent
+      #spec.template.spec.containers[1].env
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: QUARKUS_DATASOURCE_JDBC_URL
+            value: "jdbc:sqlserver://<ipaddress or hostname>:1433;databaseName=intershop;TrustServerCertificate=True;"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: QUARKUS_DATASOURCE_USERNAME
+            value: "intershop"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: QUARKUS_DATASOURCE_PASSWORD
+            value: "intershop"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: JAVA_OPTS_APPEND
+            value: "-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.interval=60S"
+      #spec.template.spec.containers[1].ports
+      - contains:
+          path: spec.template.spec.containers[1].ports
+          content:
+            name: inframonitoring
+            containerPort: 8080
+            protocol: TCP
+      #spec.template.spec.containers[0].resources
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 200Mi
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.memory
+          value: 200Mi
       #spec.template.spec.<misc>
       - equal:
           path: spec.template.spec.dnsPolicy

--- a/charts/icm-as/tests/infrastructure-monitoring_test.yaml
+++ b/charts/icm-as/tests/infrastructure-monitoring_test.yaml
@@ -26,6 +26,7 @@ tests:
     values:
       - ../values.yaml
     set:
+      infrastructureMonitoring.enabled: true
       infrastructureMonitoring.image.repository: "intershop/infrastructure-probing:0.8.15"
       infrastructureMonitoring.image.pullPolicy: "Always"
     asserts:
@@ -46,6 +47,7 @@ tests:
     values:
       - ../values.yaml
     set:
+      infrastructureMonitoring.enabled: true
       infrastructureMonitoring.databaseLatency.enabled: true
       infrastructureMonitoring.databaseLatency.interval: 10S
     asserts:
@@ -65,6 +67,7 @@ tests:
     values:
       - ../values.yaml
     set:
+      infrastructureMonitoring.enabled: true
       infrastructureMonitoring.databaseLatency.enabled: false
     asserts:
       #spec.template.spec.containers[1].env
@@ -83,6 +86,7 @@ tests:
     values:
       - ../values.yaml
     set:
+      infrastructureMonitoring.enabled: true
       infrastructureMonitoring.databaseLatency.enabled: false
     asserts:
       - isKind:

--- a/charts/icm-as/tests/infrastructure-monitoring_test.yaml
+++ b/charts/icm-as/tests/infrastructure-monitoring_test.yaml
@@ -1,0 +1,113 @@
+suite: tests the infrastructure monitoring section values
+templates:
+  - templates/as-deployment.yaml
+  - templates/infrastructure-monitoring-service.yaml
+tests:
+  - it: should not render if disabled
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      infrastructureMonitoring.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[1]
+
+  - it: image is customizable
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      infrastructureMonitoring.image.repository: "intershop/infrastructure-probing:0.8.15"
+      infrastructureMonitoring.image.pullPolicy: "Always"
+    asserts:
+      #spec.template.spec.containers[1]
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: intershop/infrastructure-probing:0.8.15
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: Always
+
+  - it: probe databaseLatency is customizable
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      infrastructureMonitoring.databaseLatency.enabled: true
+      infrastructureMonitoring.databaseLatency.interval: 10S
+    asserts:
+      #spec.template.spec.containers[1].env
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: JAVA_OPTS_APPEND
+            value: "-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.interval=10S"
+
+  - it: probe databaseLatency can be disabled
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      infrastructureMonitoring.databaseLatency.enabled: false
+    asserts:
+      #spec.template.spec.containers[1].env
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: JAVA_OPTS_APPEND
+            value: "-Dprobes.databaseLatency.enabled=false -Dprobes.databaseLatency.interval=60S"
+
+  - it: service is properly configured
+    template: templates/infrastructure-monitoring-service.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      infrastructureMonitoring.databaseLatency.enabled: false
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: icm-as-inframonitoring
+      #metadata.labels
+      - equal:
+          path: metadata.labels.app
+          value: icm-as
+      - equal:
+          path: metadata.labels.chart
+          value: icm-as-0.8.15
+      #spec.ports
+      - contains:
+          path: spec.ports
+          content:
+            name: inframonitoring
+            port: 8080
+            targetPort: inframonitoring
+      #spec.selector
+      - equal:
+          path: spec.selector.app
+          value: icm-as
+      #status
+      - isEmpty:
+          path: status.loadBalancer

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -108,7 +108,7 @@ infrastructureMonitoring:
     # enabled/disabled
     enabled: true
     # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse)
-    interval: 5S
+    interval: 60S
 
 nameOverride: ""
 

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -96,7 +96,7 @@ newrelic:
 # configuration for metrics about infrastructure components
 infrastructureMonitoring:
   # enable or disable the whole feature
-  enabled: true
+  enabled: false
   # the metrics agent requires a docker image to run
   image:
     # pull policy

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -93,6 +93,23 @@ newrelic:
     # fine grade possibility to disable apm for cost reduction
     enabled: true
 
+# configuration for metrics about infrastructure components
+infrastructureMonitoring:
+  # enable or disable the whole feature
+  enabled: true
+  # the metrics agent requires a docker image to run
+  image:
+    # pull policy
+    pullPolicy: IfNotPresent
+    # repository (incl. tag)
+    repository: "intershophub/infrastructure-probing:1.0.0"
+  # section for database latency metrics
+  databaseLatency:
+    # enabled/disabled
+    enabled: true
+    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse)
+    interval: 5S
+
 nameOverride: ""
 
 fullnameOverride: ""

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -96,7 +96,7 @@ newrelic:
 # configuration for metrics about infrastructure components
 infrastructureMonitoring:
   # enable or disable the whole feature
-  enabled: false
+  enabled: true
   # the metrics agent requires a docker image to run
   image:
     # pull policy


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

icm-as-container runs standalone (besides the init-containers) in its pod.

Issue Number: Closes #815

## What Is the New Behavior?

A second container providing a database latency metric runs alongside the icm-as-container.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

