### PR TITLE
829 - enhance icm infrastructure probing by file system probes

### DIFF
--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -156,7 +156,7 @@ tests:
           value: infrastructure-monitoring
       - equal:
           path: spec.template.spec.containers[1].image
-          value: intershophub/infrastructure-probing:1.0.0
+          value: intershophub/infrastructure-probing:2.0.0
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: IfNotPresent
@@ -180,7 +180,7 @@ tests:
           path: spec.template.spec.containers[1].env
           content:
             name: JAVA_OPTS_APPEND
-            value: "-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.interval=60S"
+            value: '-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.type="JDBC_LATENCY" -Dprobes.databaseLatency.interval="60S" -Dprobes.sitesLatency.enabled=true -Dprobes.sitesLatency.type="FILE_SYSTEM_LATENCY" -Dprobes.sitesLatency.interval="60S"-Dprobes.sitesLatency.path="/intershop/sites/root" -Dprobes.sitesReadThroughput.enabled=false -Dprobes.sitesWriteThroughput.enabled=false'
       #spec.template.spec.containers[1].ports
       - contains:
           path: spec.template.spec.containers[1].ports

--- a/charts/icm-as/tests/infrastructure-monitoring_test.yaml
+++ b/charts/icm-as/tests/infrastructure-monitoring_test.yaml
@@ -28,7 +28,7 @@ tests:
     set:
       infrastructureMonitoring.enabled: true
       infrastructureMonitoring.image.repository: "intershop/infrastructure-probing:0.8.15"
-      infrastructureMonitoring.image.pullPolicy: "Always"
+      infrastructureMonitoring.imagePullPolicy: "Always"
     asserts:
       #spec.template.spec.containers[1]
       - equal:
@@ -38,7 +38,7 @@ tests:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: Always
 
-  - it: probe databaseLatency is customizable
+  - it: probes are customizable
     template: templates/as-deployment.yaml
     release:
       name: icm-as
@@ -49,16 +49,27 @@ tests:
     set:
       infrastructureMonitoring.enabled: true
       infrastructureMonitoring.databaseLatency.enabled: true
-      infrastructureMonitoring.databaseLatency.interval: 10S
+      infrastructureMonitoring.databaseLatency.interval: 11S
+      infrastructureMonitoring.sitesLatency.enabled: true
+      infrastructureMonitoring.sitesLatency.interval: 12S
+      infrastructureMonitoring.sitesLatency.path: /intershop/sites/not-root
+      infrastructureMonitoring.sitesReadThroughput.enabled: true
+      infrastructureMonitoring.sitesReadThroughput.interval: 13S
+      infrastructureMonitoring.sitesReadThroughput.path: /intershop/sites/.readThroughputProbingCustom
+      infrastructureMonitoring.sitesReadThroughput.fileSize: 11 Mi
+      infrastructureMonitoring.sitesWriteThroughput.enabled: true
+      infrastructureMonitoring.sitesWriteThroughput.interval: 14S
+      infrastructureMonitoring.sitesWriteThroughput.path: /intershop/sites/.writeThroughputProbingCustom
+      infrastructureMonitoring.sitesWriteThroughput.fileSize: 12 Mi
     asserts:
       #spec.template.spec.containers[1].env
       - contains:
           path: spec.template.spec.containers[1].env
           content:
             name: JAVA_OPTS_APPEND
-            value: "-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.interval=10S"
+            value: '-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.type="JDBC_LATENCY" -Dprobes.databaseLatency.interval="11S" -Dprobes.sitesLatency.enabled=true -Dprobes.sitesLatency.type="FILE_SYSTEM_LATENCY" -Dprobes.sitesLatency.interval="12S"-Dprobes.sitesLatency.path="/intershop/sites/not-root" -Dprobes.sitesReadThroughput.enabled=true -Dprobes.sitesReadThroughput.type="FILE_SYSTEM_READ_THROUGHPUT" -Dprobes.sitesReadThroughput.interval="13S"-Dprobes.sitesReadThroughput.path="/intershop/sites/.readThroughputProbingCustom"-Dprobes.sitesReadThroughput.fileSize="11 Mi" -Dprobes.sitesWriteThroughput.enabled=true -Dprobes.sitesWriteThroughput.type="FILE_SYSTEM_WRITE_THROUGHPUT" -Dprobes.sitesWriteThroughput.interval="14S"-Dprobes.sitesWriteThroughput.path="/intershop/sites/.writeThroughputProbingCustom"-Dprobes.sitesWriteThroughput.fileSize="12 Mi"'
 
-  - it: probe databaseLatency can be disabled
+  - it: probes can be enabled/disabled
     template: templates/as-deployment.yaml
     release:
       name: icm-as
@@ -69,13 +80,16 @@ tests:
     set:
       infrastructureMonitoring.enabled: true
       infrastructureMonitoring.databaseLatency.enabled: false
+      infrastructureMonitoring.sitesLatency.enabled: false
+      infrastructureMonitoring.sitesReadThroughput.enabled: true
+      infrastructureMonitoring.sitesWriteThroughput.enabled: true
     asserts:
       #spec.template.spec.containers[1].env
       - contains:
           path: spec.template.spec.containers[1].env
           content:
             name: JAVA_OPTS_APPEND
-            value: "-Dprobes.databaseLatency.enabled=false -Dprobes.databaseLatency.interval=60S"
+            value: '-Dprobes.databaseLatency.enabled=false -Dprobes.sitesLatency.enabled=false -Dprobes.sitesReadThroughput.enabled=true -Dprobes.sitesReadThroughput.type="FILE_SYSTEM_READ_THROUGHPUT" -Dprobes.sitesReadThroughput.interval="60S"-Dprobes.sitesReadThroughput.path="/intershop/sites/.readThroughputProbing"-Dprobes.sitesReadThroughput.fileSize="5 Mi" -Dprobes.sitesWriteThroughput.enabled=true -Dprobes.sitesWriteThroughput.type="FILE_SYSTEM_WRITE_THROUGHPUT" -Dprobes.sitesWriteThroughput.interval="60S"-Dprobes.sitesWriteThroughput.path="/intershop/sites/.writeThroughputProbing"-Dprobes.sitesWriteThroughput.fileSize="5 Mi"'
 
   - it: service is properly configured
     template: templates/infrastructure-monitoring-service.yaml

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -102,13 +102,41 @@ infrastructureMonitoring:
     # pull policy
     pullPolicy: IfNotPresent
     # repository (incl. tag)
-    repository: "intershophub/infrastructure-probing:1.0.0"
+    repository: "intershophub/infrastructure-probing:2.0.0"
   # section for database latency metrics
   databaseLatency:
-    # enabled/disabled
+    # enabled/disabled (default=false)
     enabled: true
-    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse)
+    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse, default=60S)
     interval: 60S
+  # section for sites storage latency metrics
+  sitesLatency:
+    # enabled/disabled (default=false)
+    enabled: true
+    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse, default=60S)
+    interval: 60S
+    # which path has to be used (mandatory)
+    path: /intershop/sites/root
+  # section for sites storage latency metrics
+  sitesReadThroughput:
+    # enabled/disabled (default=false)
+    enabled: false
+    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse, default=60S)
+    interval: 60S
+    # which path has to be used (mandatory)
+    path: /intershop/sites/.readThroughputProbing
+    # size of the file to be read (format compatible to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/, default=5 Mi)
+    fileSize: 5 Mi
+  # section for sites storage latency metrics
+  sitesWriteThroughput:
+    # enabled/disabled (default=false)
+    enabled: false
+    # how often to gather a sample for the metrics (pattern compatible to java.time.Duration#parse, default=60S)
+    interval: 60S
+    # which path has to be used (mandatory)
+    path: /intershop/sites/.writeThroughputProbing
+    # size of the file to be written (format compatible to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/, default=5 Mi)
+    fileSize: 5 Mi
 
 nameOverride: ""
 


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

Issue Number: Closes #829

## What Is the New Behavior?

File system probes are now supported:
* latency for `/intershop/sites` (enabled by default)
* read throughput for `/intershop/sites` (disabled by default)
* write throughput for `/intershop/sites` (disabled by default)

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

