### PR TITLE
fix: fix inframon jvm-options (#837)

### DIFF
--- a/charts/icm-as/templates/_infrastructureMonitoring.tpl
+++ b/charts/icm-as/templates/_infrastructureMonitoring.tpl
@@ -92,8 +92,6 @@ replace:  '.Values.infrastructureMonitoring.databaseLatency' by the probe's valu
 {{- $probeType := $probeOpts.type }}
 {{- if $isEnabled -}}
 {{- printf "-Dprobes.%s.enabled=%t -Dprobes.%s.type=%s -Dprobes.%s.interval=%s" $probeName $isEnabled $probeName (quote $probeType) $probeName (quote (default "60S" $probeValues.interval)) -}}
-{{- else -}}
-{{- printf "-Dprobes.%s.enabled=%t" $probeName $isEnabled -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -156,7 +156,7 @@ tests:
           value: infrastructure-monitoring
       - equal:
           path: spec.template.spec.containers[1].image
-          value: intershophub/infrastructure-probing:2.0.0
+          value: intershophub/infrastructure-probing:2.0.1
       - equal:
           path: spec.template.spec.containers[1].imagePullPolicy
           value: IfNotPresent
@@ -180,7 +180,7 @@ tests:
           path: spec.template.spec.containers[1].env
           content:
             name: JAVA_OPTS_APPEND
-            value: '-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.type="JDBC_LATENCY" -Dprobes.databaseLatency.interval="60S" -Dprobes.sitesLatency.enabled=true -Dprobes.sitesLatency.type="FILE_SYSTEM_LATENCY" -Dprobes.sitesLatency.interval="60S" -Dprobes.sitesLatency.path="/intershop/sites/root" -Dprobes.sitesReadThroughput.enabled=false -Dprobes.sitesWriteThroughput.enabled=false'
+            value: '-Dprobes.databaseLatency.enabled=true -Dprobes.databaseLatency.type="JDBC_LATENCY" -Dprobes.databaseLatency.interval="60S" -Dprobes.sitesLatency.enabled=true -Dprobes.sitesLatency.type="FILE_SYSTEM_LATENCY" -Dprobes.sitesLatency.interval="60S" -Dprobes.sitesLatency.path="/intershop/sites/root"  '
       #spec.template.spec.containers[1].ports
       - contains:
           path: spec.template.spec.containers[1].ports

--- a/charts/icm-as/tests/infrastructure-monitoring_test.yaml
+++ b/charts/icm-as/tests/infrastructure-monitoring_test.yaml
@@ -89,7 +89,7 @@ tests:
           path: spec.template.spec.containers[1].env
           content:
             name: JAVA_OPTS_APPEND
-            value: '-Dprobes.databaseLatency.enabled=false -Dprobes.sitesLatency.enabled=false -Dprobes.sitesReadThroughput.enabled=true -Dprobes.sitesReadThroughput.type="FILE_SYSTEM_READ_THROUGHPUT" -Dprobes.sitesReadThroughput.interval="60S" -Dprobes.sitesReadThroughput.path="/intershop/sites/.readThroughputProbing" -Dprobes.sitesReadThroughput.fileSize="5 Mi" -Dprobes.sitesWriteThroughput.enabled=true -Dprobes.sitesWriteThroughput.type="FILE_SYSTEM_WRITE_THROUGHPUT" -Dprobes.sitesWriteThroughput.interval="60S" -Dprobes.sitesWriteThroughput.path="/intershop/sites/.writeThroughputProbing" -Dprobes.sitesWriteThroughput.fileSize="5 Mi"'
+            value: '  -Dprobes.sitesReadThroughput.enabled=true -Dprobes.sitesReadThroughput.type="FILE_SYSTEM_READ_THROUGHPUT" -Dprobes.sitesReadThroughput.interval="60S" -Dprobes.sitesReadThroughput.path="/intershop/sites/.readThroughputProbing" -Dprobes.sitesReadThroughput.fileSize="5 Mi" -Dprobes.sitesWriteThroughput.enabled=true -Dprobes.sitesWriteThroughput.type="FILE_SYSTEM_WRITE_THROUGHPUT" -Dprobes.sitesWriteThroughput.interval="60S" -Dprobes.sitesWriteThroughput.path="/intershop/sites/.writeThroughputProbing" -Dprobes.sitesWriteThroughput.fileSize="5 Mi"'
 
   - it: service is properly configured
     template: templates/infrastructure-monitoring-service.yaml

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -102,7 +102,7 @@ infrastructureMonitoring:
     # pull policy
     pullPolicy: IfNotPresent
     # repository (incl. tag)
-    repository: "intershophub/infrastructure-probing:2.0.0"
+    repository: "intershophub/infrastructure-probing:2.0.1"
   # section for database latency metrics
   databaseLatency:
     # enabled/disabled (default=false)


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Disabled infrastructure monitoring probes make the infrastructure monitoring sidecar container fail on startup

Issue Number: Closes #837

## What Is the New Behavior?

Disabled infrastructure monitoring probes no longer make the infrastructure monitoring sidecar container fail on startup

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

