### PR TITLE
feat (icm): enable timeoutSeconds for icm-wa (#845)

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -180,6 +180,7 @@ spec:
             initialDelaySeconds: {{ .Values.webadapter.probes.startup.initialDelaySeconds | default 0 }}
             periodSeconds: {{ .Values.webadapter.probes.startup.periodSeconds | default 5 }}
             failureThreshold: {{ .Values.webadapter.probes.startup.failureThreshold | default 6 }}
+            timeoutSeconds: {{ .Values.webadapter.probes.startup.timeoutSeconds | default 1 }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.service.httpPort }}
@@ -187,6 +188,7 @@ spec:
             initialDelaySeconds: {{ .Values.webadapter.probes.liveness.initialDelaySeconds | default 0 }}
             periodSeconds: {{ .Values.webadapter.probes.liveness.periodSeconds | default 10 }}
             failureThreshold: {{ .Values.webadapter.probes.liveness.failureThreshold | default 3 }}
+            timeoutSeconds: {{ .Values.webadapter.probes.liveness.timeoutSeconds | default 1 }}
           readinessProbe:
             httpGet:
               # /INTERSHOP/wastatus response code is directly linked to configuration servlet availability/validity and
@@ -200,6 +202,7 @@ spec:
             initialDelaySeconds: {{ .Values.webadapter.probes.readiness.initialDelaySeconds | default 0 }}
             periodSeconds: {{ .Values.webadapter.probes.readiness.periodSeconds | default 10 }}
             failureThreshold: {{ .Values.webadapter.probes.readiness.failureThreshold | default 3 }}
+            timeoutSeconds: {{ .Values.webadapter.probes.readiness.timeoutSeconds | default 1 }}
           volumeMounts:
           {{- if .Values.webadapter.customHttpdConfig }}
           - name: httpd-config-volume

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -37,14 +37,17 @@ webadapter:
     #  initialDelaySeconds: 0
     #  periodSeconds: 5
     #  failureThreshold: 6
+    #  timeoutSeconds: 1
     liveness: {}
     #  initialDelaySeconds: 0
     #  periodSeconds: 10
     #  failureThreshold: 3
+    #  timeoutSeconds: 1
     readiness: {}
     #  initialDelaySeconds: 0
     #  periodSeconds: 10
     #  failureThreshold: 3
+    #  timeoutSeconds: 1
   sslCertificateRetrieval:
     enabled: false
     supportV1: false


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Feature

## What Is the Current Behavior?

timeoutSeconds is not configurable for the webadapter probes

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #845

## What Is the New Behavior?

timeoutSeconds is configurable for the webadapter probes

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
