### PR TITLE
fix (icm): wastatus could last longer (#852)

### DIFF
--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -202,7 +202,7 @@ spec:
             initialDelaySeconds: {{ .Values.webadapter.probes.readiness.initialDelaySeconds | default 0 }}
             periodSeconds: {{ .Values.webadapter.probes.readiness.periodSeconds | default 10 }}
             failureThreshold: {{ .Values.webadapter.probes.readiness.failureThreshold | default 3 }}
-            timeoutSeconds: {{ .Values.webadapter.probes.readiness.timeoutSeconds | default 1 }}
+            timeoutSeconds: {{ .Values.webadapter.probes.readiness.timeoutSeconds | default 5 }}
           volumeMounts:
           {{- if .Values.webadapter.customHttpdConfig }}
           - name: httpd-config-volume


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix


## What Is the Current Behavior?

Sometime deployment fails due to a small timeout value for wastatus readiness probe

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #852

## What Is the New Behavior?

The default timeout is now set to 5s

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

