### PR TITLE
feat(icm): added hostAliases + dnsConfig config to icm-as (#912)

### DIFF
--- a/charts/icm-as/README.md
+++ b/charts/icm-as/README.md
@@ -82,7 +82,7 @@ Prerequisites are:
 Please check the unit tests before pushing changes.
 
 ```bash
-helm unittest --helm3 charts/icm-as
+helm unittest charts/icm-as
 ```
 
 #### ct lint & install

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -195,6 +195,26 @@ securityContext:
 {{- end -}}
 
 {{/*
+Add entries to a Pod's /etc/hosts
+*/}}
+{{- define "icm-as.hostAliases" -}}
+{{- if .Values.hostAliases -}}
+hostAliases:
+  {{- toYaml .Values.hostAliases | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Customize DNS configuration
+*/}}
+{{- define "icm-as.dnsConfig" -}}
+{{- if .Values.dnsConfig -}}
+dnsConfig:
+  {{- toYaml .Values.dnsConfig | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
 The discovery mode of jgroups messaging
 */}}
 {{- define "icm-as.jgroups.discovery" -}}

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -73,5 +73,11 @@ spec:
       {{- if include "icm-as.podSecurityContext" . }}
         {{- include "icm-as.podSecurityContext" . | nindent 6 }}
       {{- end }}
+      {{- if include "icm-as.hostAliases" . }}
+        {{- include "icm-as.hostAliases" . | nindent 6 }}
+      {{- end }}
+      {{- if include "icm-as.dnsConfig" . }}
+        {{- include "icm-as.dnsConfig" . | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- include "icm-as.volumes" . | nindent 6 }}

--- a/charts/icm-as/templates/jobserver-deployment.yaml
+++ b/charts/icm-as/templates/jobserver-deployment.yaml
@@ -67,6 +67,12 @@ spec:
           {{- if include "icm-as.podSecurityContext" $jobValues }}
             {{- include "icm-as.podSecurityContext" $jobValues | nindent 10 }}
           {{- end }}
+          {{- if include "icm-as.hostAliases" . }}
+            {{- include "icm-as.hostAliases" . | nindent 10 }}
+          {{- end }}
+          {{- if include "icm-as.dnsConfig" . }}
+            {{- include "icm-as.dnsConfig" . | nindent 10 }}
+          {{- end }}
           {{- include "icm-as.volumes" . | nindent 10 }}
 {{- end -}}
 

--- a/charts/icm-as/tests/dns_config_test.yaml
+++ b/charts/icm-as/tests/dns_config_test.yaml
@@ -1,0 +1,42 @@
+suite: test correctness of dnsConfig
+templates:
+  - templates/as-deployment.yaml
+tests:
+  - it: Should not have any dnsConfig by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.dnsConfig
+
+  - it: Should contain specified dnsConfig values
+    set:
+      dnsConfig:
+        nameservers:
+          - "192.0.2.1"
+        searches:
+          - "ns1.svc.cluster-domain.example"
+          - "my.dns.search.suffix"
+        options:
+          - name: "ndots"
+            value: "2"
+          - name: "edns0"
+    asserts:
+      - exists:
+          path: spec.template.spec.dnsConfig
+      - equal:
+          path: spec.template.spec.dnsConfig.nameservers[0]
+          value: "192.0.2.1"
+      - equal:
+          path: spec.template.spec.dnsConfig.searches[0]
+          value: "ns1.svc.cluster-domain.example"
+      - equal:
+          path: spec.template.spec.dnsConfig.searches[1]
+          value: "my.dns.search.suffix"
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].name
+          value: "ndots"
+      - equal:
+          path: spec.template.spec.dnsConfig.options[0].value
+          value: "2"
+      - equal:
+          path: spec.template.spec.dnsConfig.options[1].name
+          value: "edns0"

--- a/charts/icm-as/tests/host_aliases_test.yaml
+++ b/charts/icm-as/tests/host_aliases_test.yaml
@@ -1,0 +1,24 @@
+suite: test correctness of hostAliases
+templates:
+  - templates/as-deployment.yaml
+tests:
+  - it: Should not have any hostAliases by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostAliases
+
+  - it: Should contain specified hostAliases
+    set:
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "foo.local"
+    asserts:
+      - exists:
+          path: spec.template.spec.hostAliases
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: "127.0.0.1"
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: "foo.local"

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -181,6 +181,22 @@ podSecurityContext:
   runAsNonRoot: true
   fsGroupChangePolicy: "OnRootMismatch"
 
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+
+dnsConfig: {}
+#  nameservers:
+#  - 192.0.2.1 # this is an example
+#  searches:
+#  - ns1.svc.cluster-domain.example
+#  - my.dns.search.suffix
+#  options:
+#  - name: ndots
+#    value: "2"
+#  - name: edns0
+
 testConnection:
   protocol: http
   port: 7743


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Feature

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

hostAliases and dnsConfig are not configurable in icm-as

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #912

## What Is the New Behavior?

hostAliases and dnsConfig are not configurable in icm-as

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No
