### PR TITLE
fix: version comparision for replication fixed (#974)

### DIFF
--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -127,8 +127,8 @@ Creates the environment replication section
 ICM-AS >= 12.2.0 supports new replication configuration via environments instead of replication-clusters.xml
 ICM-AS >= 13.0.0 requires new replication configuration
 */}}
-{{- $icmApplicationServerImageSemanticVersion := include "icm-as.imageSemanticVersion" . -}}
-{{- $hasIcmApplicationServerImageSemanticVersion := regexMatch "([0-9]+)\\.([0-9]+)\\.([0-9]+)" $icmApplicationServerImageSemanticVersion -}}
+{{- $icmApplicationServerImageSemanticVersion := splitList "-" (include "icm-as.imageSemanticVersion" .) | first -}}
+{{- $hasIcmApplicationServerImageSemanticVersion := regexMatch "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$" $icmApplicationServerImageSemanticVersion -}}
 {{- $hasNewReplicationConfigurationRequirement := and ($hasIcmApplicationServerImageSemanticVersion) (semverCompare ">= 13.0.0" $icmApplicationServerImageSemanticVersion) -}}
 {{- $hasNewReplicationConfigurationSupport := and ($hasIcmApplicationServerImageSemanticVersion) (semverCompare ">= 12.2.0" $icmApplicationServerImageSemanticVersion) -}}
 {{- $hasNewReplicationConfiguration := or (hasKey .Values.replication "source") (hasKey .Values.replication "targets") -}}

--- a/charts/icm-as/tests/replication_test.yaml
+++ b/charts/icm-as/tests/replication_test.yaml
@@ -775,6 +775,30 @@ tests:
       - failedTemplate:
           errorMessage: "Error: The new replication configuration 'replication.source'/'replication.targets' can be only used with ICM-AS 12.2.0 and newer, currently used '12.1.0'."
 
+  - it: as-deployment should not fail if version ends with string
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.source:
+        webserverUrl: https://icm-web-edit-wa:443
+        databaseUser: repl_user_edit
+      replication.targets:
+        live1:
+          webserverUrl: https://icm-web-live-wa:443
+          databaseUser: repl_user_live
+      image:
+        tag: 12.4.2-SNAPSHOT
+    template: templates/as-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
   - it: as-deployment fails with both databaseLink and databaseName
     release:
       name: icm-as

--- a/charts/icm-replication/values-test-local.tmpl
+++ b/charts/icm-replication/values-test-local.tmpl
@@ -1,6 +1,8 @@
 icm-edit:
   icm-as:
     nodeSelector: null
+    infrastructureMonitoring:
+      enabled: false
     imagePullSecrets:
     - "${ICM_AS_PULL_SECRET}"
     persistence:
@@ -13,10 +15,31 @@ icm-edit:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc
         mountPoint: /data
+    mssql:
+      enabled: true
+      acceptEula: "Y"
+      persistence:
+        data:
+          size: 1Gi
+          type: local
+          local:
+            path: ${LOCAL_MOUNT_BASE}/mssql-edit/data
+        backup:
+          size: 1Gi
+          type: local
+          local:
+            path: ${LOCAL_MOUNT_BASE}/mssql-edit/backup
+  icm-web:
+    nodeSelector: null
+    persistence:
+      customdata:
+        existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc
 
 icm-live:
   icm-as:
     nodeSelector: null
+    infrastructureMonitoring:
+      enabled: false
     imagePullSecrets:
     - "${ICM_AS_PULL_SECRET}"
     persistence:
@@ -29,6 +52,29 @@ icm-live:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc
         mountPoint: /data
+    mssql:
+      enabled: true
+      acceptEula: "Y"
+      persistence:
+        data:
+          size: 1Gi
+          type: local
+          local:
+            path: ${LOCAL_MOUNT_BASE}/mssql-live/data
+        backup:
+          size: 1Gi
+          type: local
+          local:
+            path: ${LOCAL_MOUNT_BASE}/mssql-live/backup
+  icm-web:
+    nodeSelector: null
+    persistence:
+      customdata:
+        existingClaim: ${HELM_JOB_NAME}-icm-live-local-testdata-pvc
+
+  ingress-nginx:
+    controller:
+      nodeSelector: null
 
   mailhog:
     nodeSelector: null

--- a/charts/icm/values-test-local.tmpl
+++ b/charts/icm/values-test-local.tmpl
@@ -1,5 +1,7 @@
 icm-as:
   nodeSelector: null
+  infrastructureMonitoring:
+    enabled: false
   imagePullSecrets:
   - "${ICM_AS_PULL_SECRET}"
   persistence:


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

icm-replication deployment fails when version 12.4.2-SNAPSHOT is used.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #974

## What Is the New Behavior?

icm-replication deployment works also with 12.4.2-SNAPSHOT.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No

