### PR TITLE
support custom tls certificates in icm as jvm

### DIFF
--- a/charts/icm-as/README.md
+++ b/charts/icm-as/README.md
@@ -4,14 +4,14 @@ Installs the ICM application server independently.
 
 ## Prerequisites Details
 
-* helm+kubectl
-* Kubernetes 1.14+
+- helm+kubectl
+- Kubernetes 1.14+
 
 ## Chart Details
 
 This chart will do the following:
 
-* Deploy an ICM Application Server
+- Deploy an ICM Application Server
 
 ## Installing the Chart
 
@@ -41,7 +41,7 @@ The needed database connection could be configured via section `database`. The c
 
 ### Replication/Staging
 
-A replication/staging scenario is supported via the section `replication`. To use this feature just deploy 2 separate icm-as (+ icm-web) one for the source (*edit*) system and one for the target (*live*) system.
+A replication/staging scenario is supported via the section `replication`. To use this feature just deploy 2 separate icm-as (+ icm-web) one for the source (_edit_) system and one for the target (_live_) system.
 
 ### Add the Intershop Helm repository
 
@@ -77,7 +77,7 @@ There are helm-unit tests to support development and secure several functionalit
 
 Prerequisites are:
 
-* [helm-unittest](https://github.com/helm-unittest/helm-unittest)
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest)
 
 Please check the unit tests before pushing changes.
 
@@ -89,10 +89,15 @@ helm unittest charts/icm-as
 
 Prerequisites are:
 
-* [kind cluster](https://github.com/kubernetes-sigs/kind)
-* Install cluster: `kind create cluster --config icm-as.yaml`
+- [kind cluster](https://github.com/kubernetes-sigs/kind)
+- Install cluster: `kind create cluster --config icm-as.yaml`
 
 ```bash
 docker run -it --network host --workdir=/data --volume <my kube config>:/root/.kube/config:ro --volume
 $(pwd):/data quay.io/helmpack/chart-testing:v3.8.0 ct lint --config ct_icm-as.yaml
 ```
+
+## Detailed documentation
+
+- [values.yaml documentation](docs/values-yaml.md)
+- [How to ...](docs/how-to.md)

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -156,9 +156,6 @@ Image spec
 {{- define "icm-as.image" -}}
 image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
 imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-{{- if .Values.customCommand }}
-command: {{- toYaml .Values.customCommand | nindent 2 }}
-{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -4,7 +4,7 @@ Creates init-containers
 */}}
 {{- define "icm-as.initContainers" -}}
 initContainers:
-{{- if eq .Values.persistence.sites.type "local" }}
+{{- if eq .Values.persistence.sites.type "local_" }}
 # the following container
 # 1) only is active if local storage is enabled
 # 2) applies permission 777 to sites volume

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -45,4 +45,22 @@ volumeMounts:
 - mountPath: /mnt/secrets
   name: secrets-store-inline
 {{- end }}
-{{- end -}}
+{{- if .Values.secretMounts }}
+{{- range $index, $mount := .Values.secretMounts }}
+{{- $type := default "secret" $mount.type }}
+{{- $mountPath := "" }}
+{{- if $mount.targetFile }}
+{{- if eq $type "secret" }}
+  {{- $mountPath = "/secrets" }}
+{{- else if eq $type "certificate" }}
+  {{- $mountPath = "/certificates" }}
+{{- else }}
+  {{- fail (printf "Error: invalid value '%s' at secretMounts[%d].type, must be one of (secret,certificate), default=secret." $type $index) -}}
+{{- end }}
+- name: secretmount-{{ $index }}
+  mountPath: {{ $mountPath | quote }}
+  readOnly: true
+{{- end }} {{/*if $mount.targetFile*/}}
+{{- end }} {{/*range*/}}
+{{- end }} {{/*if .Values.secretMounts*/}}
+{{- end -}} {{/*define "icm-as.volumeMounts"*/}}

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -44,7 +44,27 @@ volumes:
     volumeAttributes:
       secretProviderClass: {{ include "icm-as.fullname" . }}-cert
 {{- end }}
-{{- end -}}
+{{- if .Values.secretMounts }}
+{{- range $index, $mount := .Values.secretMounts }}
+{{- $type := default "secret" $mount.type }}
+{{- $key := $mount.key }}
+{{- if eq $type "certificate" }}
+  {{- $key = default "tls.crt" $key }}
+{{- end }}
+{{- if not $key }}
+  {{- fail (printf "Error: missing value at secretMounts[%d].key" $index) -}}
+{{- end }}
+{{- if $mount.targetFile }}
+- name: secretmount-{{ $index }}
+  secret:
+    secretName: {{ $mount.secretName | quote }}
+    items:
+    - key: {{ $key | quote }}
+      path: {{ $mount.targetFile | quote }}
+{{- end }} {{/*if $mount.targetFile*/}}
+{{- end }} {{/*range*/}}
+{{- end }} {{/*if .Values.secretMounts*/}}
+{{- end -}} {{/*define "icm-as.volumes"*/}}
 
 {{/*
 Creates a volume named {$name}-volume

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -58,6 +58,19 @@ spec:
       {{- end }}
       containers:
       - name: icm-as-server
+        {{- if .Values.customCommand }}
+        command: {{- toYaml .Values.customCommand | nindent 10 }}
+        {{- else }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            source /__cacert_entrypoint.sh && \
+            ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+            printf '%.0s-' {1..80} && \
+            echo && \
+            /intershop/bin/intershop.sh
+        {{- end }}
         {{- include "icm-as.image" . | nindent 8 }}
         {{- include "icm-as.envAS" . | nindent 8 }}
         {{- include "icm-as.ports" . | nindent 8 }}

--- a/charts/icm-as/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-as/templates/ssl-certificate-spc.yaml
@@ -19,7 +19,7 @@ spec:
       key: tls.crt
   parameters:
     usePodIdentity: "true"                                                          # [OPTIONAL for Azure] if not provided, will default to "false"
-    tenantId: "{{ .Values.sslCertificateRetrieval.keyvault.tenantId }}"             # the tenant ID of the KeyVault
+    tenantId: "{{ .Values.sslCertificateRetrieval.keyvault.tenantId }}"             # the tenant ID / Directory ID of the KeyVault
     subscriptionId: "{{ .Values.sslCertificateRetrieval.keyvault.subscriptionId }}" # [REQUIRED for version < 0.0.4] the subscription ID of the KeyVault
     resourceGroup: "{{ .Values.sslCertificateRetrieval.keyvault.resourceGroup }}"   # [REQUIRED for version < 0.0.4] the resource group of the KeyVault
     keyvaultName: "{{ .Values.sslCertificateRetrieval.keyvault.keyvaultName }}"     # the name of the KeyVault

--- a/charts/icm-as/tests/custom-command_test.yaml
+++ b/charts/icm-as/tests/custom-command_test.yaml
@@ -11,8 +11,17 @@ tests:
       - ../values.yaml
     template: templates/as-deployment.yaml
     asserts:
-      - isNull:
+      - equal:
           path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - -c
+            - |
+              source /__cacert_entrypoint.sh && \
+              ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+              printf '%.0s-' {1..80} && \
+              echo && \
+              /intershop/bin/intershop.sh
 
   - it: customComamnd is empty
     release:
@@ -25,8 +34,17 @@ tests:
       customComamnd: []
     template: templates/as-deployment.yaml
     asserts:
-      - isNull:
+      - equal:
           path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - -c
+            - |
+              source /__cacert_entrypoint.sh && \
+              ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+              printf '%.0s-' {1..80} && \
+              echo && \
+              /intershop/bin/intershop.sh
 
   - it: customComamnd is provided
     release:

--- a/charts/icm-as/tests/customizations_test.yaml
+++ b/charts/icm-as/tests/customizations_test.yaml
@@ -13,12 +13,8 @@ tests:
       customizations: {}
     template: templates/as-deployment.yaml
     asserts:
-      - contains:
+      - isNullOrEmpty:
           path: spec.template.spec.initContainers
-          content:
-            name: sites-volume-mount-hack
-          count: 1
-          any: true
 
   - it: one customization with default pullPolicy
     release:

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -220,10 +220,28 @@ environment:
   CARTRIDGE_LIST: "ft_icm_as"
 
 # environment variable secrets to be propagated to the icm-as-container
-secrets:
+# @Deprecated since 2.9.0, replaced by secretMounts with targetEnv provided
+secrets: []
   # - env: <YOUR_MAIL_PASSWORD> # environment variable key
   #  name: <emailSecrets> # name of the secret, containing the referenced key
   #  key: <smtpPassword> # key within the secret
+
+# Configure the secret mounts for the ICM application server.
+# List 0..n secret mounts consisting of the following properties: secretName[, type][, key,][, targetFile][, targetEnv]
+# If more than one field has to be mounted from a single secret add multiple entries with the same secretName (different targetFile|targetEnv).
+# If targetFile is provided the secret's value will be mounted as a file
+# If targetEnv is provided the secret's value set a an environment variable
+# If neither targetFile nor targetEnv is provided the secret's value not be available
+# Secrets of type "certificate" are imported into the JVM's truststore
+# See https://support.intershop.com/kb/index.php/Display/X31381 for details on how to make secrets and certificates from an Azure KeyVault available in K8s secrets
+secretMounts: # array containing the secret mappings to be mounted
+  - secretName: <secretName> # name of the secret
+    type: secret # target type inside the ICM, supported values incl. mount path
+                      # secret (default) -> /secrets
+                      # certificate -> /certificates
+    key:  data # data field inside the secret, optional for type=certificate with default=tls.crt
+    targetFile: <releativeFileName> # path relative to the parent path defined by the type, optional, if ommited no file will be mounted
+    targetEnv: <ENV_VARIABLE_NAME> # name of the environment variable to be set, optional, if ommited no variable will be set
 
 persistence:
   sites:
@@ -443,6 +461,7 @@ webLayer:
     # Redisson client yaml config
     config: null
 
+# @Deprecated since 2.9.0, replaced by secretMounts
 sslCertificateRetrieval:
   enabled: false
   supportV1: false


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

There's no way to import custom TLS certificates into the icm-as JVM's truststore

Issue Number: Closes #1001

## What Is the New Behavior?

* certificates can be imported into the truststore
* the values.yaml section `secretMounts`  replaces the section `secrets`

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

