### PR TITLE
#104561: Added variable 'replication:classic'

### DIFF
--- a/charts/icm-as/Chart.yaml
+++ b/charts/icm-as/Chart.yaml
@@ -5,3 +5,9 @@ version: 2.8.5
 description: Intershop Commerce Management - AppServer
 type: application
 appVersion: 11.10.3-LTS
+
+dependencies:
+  - name: ingress-nginx
+    version: 4.11.1
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: ingress-nginx.enabled

--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -123,6 +123,8 @@ Creates the environment replication section
   {{- else }}
   value: live
   {{- end }}
+- name: STAGING_PROCESS_CLASSIC
+  value: {{ .Values.replication.classic | quote}}
 {{/*
 ICM-AS >= 12.2.0 supports new replication configuration via environments instead of replication-clusters.xml
 ICM-AS >= 13.0.0 requires new replication configuration

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -487,6 +487,10 @@ replication:
   # enables/disables the replication support: whether this icm-as is part of a replication system or not
   enabled: false
 
+  # enables/disables the classic, pipeline-based replication mode.
+  # Note: Performing replication by live-job-server requires classic: false.
+  classic: false
+
   # defines the type of this replication system (source | target)
   role: <source|target>
 
@@ -508,22 +512,27 @@ replication:
 #    # the external URL of the webServer/proxy/ingress e.g. https://icm-web-edit-wa:443
 #    webserverUrl: <sourceExternalUrl>
 #    # either mutual exclusive databaseName or databaseLink have to be configured
+#    # linked database mode: the edit database is accessed by the live system via a database link
 #    databaseLink: <sourceDatabaseLink>
-#    databaseUser: <sourceDatabaseUser>
+#    # local-database-mode: edit and live database are located on the same database server
 #    databaseName: <sourceDatabaseName>
 
-  # Configuration for all target systems that participates in replication
+# Configuration for all target systems that participates in replication
 #  targets:
 #    # create multiple target systems - please avoid characters like '.', '-' or '_' in the chosen name/key
 #    live1:
 #      # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+#      # note: Use 'https:' because replication uses REST services which require https
 #      webserverUrl: <targetExternalUrl>
-#      # this database user will be granted access to the database schema of the source replication system
+#      # (optional) this database user will be granted access to the database schema of the source replication system,
+#      # only necessary if direct access to the source-database is required (local-database-mode)
 #      databaseUser: <targetDatabaseUser>
 #    live2:
 #      # the external URL of the webServer/proxy/ingress e.g. https://icm-web-live-wa:443
+#      # note: Use 'https:' because replication uses REST services which require https
 #      webserverUrl: <targetExternalUrl>
-#      # this database user will be granted access to the database schema of the source replication system
+#      # (optional) this database user will be granted access to the database schema of the source replication system,
+#      # only necessary if direct access to the source-database is required (local-database-mode)
 #      databaseUser: <targetDatabaseUser>
 
 # Configuration of messaging via jgroups


### PR DESCRIPTION
This boolean can be used to choose the replication execution framework mode. Either use 'true' to use historic pipeline-based approach, or 'false' in order to use the new implementation.

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

Currently the ICM replication processes use the historic pipeline based execution framework.

Issue Number: Closes #

## What Is the New Behavior?

Using the newly provided value 'replication:classic:[true|false]', this can be switched to the new fully Java based framwork. Use classic:false to do so.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ x] No

## Other Information
