### PR TITLE
support custom tls certificates in icm as jvm

### DIFF
--- a/charts/icm-as/README.md
+++ b/charts/icm-as/README.md
@@ -4,14 +4,14 @@ Installs the ICM application server independently.
 
 ## Prerequisites Details
 
-* helm+kubectl
-* Kubernetes 1.14+
+- helm+kubectl
+- Kubernetes 1.14+
 
 ## Chart Details
 
 This chart will do the following:
 
-* Deploy an ICM Application Server
+- Deploy an ICM Application Server
 
 ## Installing the Chart
 
@@ -41,7 +41,7 @@ The needed database connection could be configured via section `database`. The c
 
 ### Replication/Staging
 
-A replication/staging scenario is supported via the section `replication`. To use this feature just deploy 2 separate icm-as (+ icm-web) one for the source (*edit*) system and one for the target (*live*) system.
+A replication/staging scenario is supported via the section `replication`. To use this feature just deploy 2 separate icm-as (+ icm-web) one for the source (_edit_) system and one for the target (_live_) system.
 
 ### Add the Intershop Helm repository
 
@@ -77,7 +77,7 @@ There are helm-unit tests to support development and secure several functionalit
 
 Prerequisites are:
 
-* [helm-unittest](https://github.com/helm-unittest/helm-unittest)
+- [helm-unittest](https://github.com/helm-unittest/helm-unittest)
 
 Please check the unit tests before pushing changes.
 
@@ -89,10 +89,15 @@ helm unittest charts/icm-as
 
 Prerequisites are:
 
-* [kind cluster](https://github.com/kubernetes-sigs/kind)
-* Install cluster: `kind create cluster --config icm-as.yaml`
+- [kind cluster](https://github.com/kubernetes-sigs/kind)
+- Install cluster: `kind create cluster --config icm-as.yaml`
 
 ```bash
 docker run -it --network host --workdir=/data --volume <my kube config>:/root/.kube/config:ro --volume
 $(pwd):/data quay.io/helmpack/chart-testing:v3.8.0 ct lint --config ct_icm-as.yaml
 ```
+
+## Detailed documentation
+
+- [values.yaml documentation](docs/values-yaml.md)
+- [How to ...](docs/how-to.md)

--- a/charts/icm-as/docs/how-to.md
+++ b/charts/icm-as/docs/how-to.md
@@ -1,0 +1,13 @@
+# What has to be done to reach a certain goal
+
+## Make a custom TLS certificate available to the `icm-as-server`-container's JVM
+
+1. Follow [Guide - Secret Store Process](https://support.intershop.com/kb/index.php/Display/X31381) to create a secret in the K8s cluster using a certificate stored inside an Azure Key Vault.
+2. Add an entry inside the [secretMounts](#secretMounts)-section
+
+   - reference the secret created from step 1
+   - set `type` to `certificate`
+   - set `key` to `tls.crt` or omit the `key`
+   - set `targetFile` to a valid file name using the file extension `.crt`
+
+   > The certificate will then be imported into the truststore of the JVM using the alias built from the base file name.

--- a/charts/icm-as/docs/values-yaml.md
+++ b/charts/icm-as/docs/values-yaml.md
@@ -1,0 +1,114 @@
+# Documentation about what can be configured using the `values.yaml`-file
+
+## State of this document
+
+> Currently this document is created an filled with new content. So it is by far not a complete documentation!
+
+## Sections
+
+The following table gives a short overview about the different sections.
+
+| Section                       | Topic                                                  |
+| ----------------------------- | ------------------------------------------------------ |
+| nodeSelector                  | agent pool assignment                                  |
+| deploymentAnnotations         | annotations for deployment                             |
+| podAnnotations                | annotations for pods                                   |
+| podBindings                   | pod bindings                                           |
+| deploymentLabels              | labels for deployment                                  |
+| podLabels                     | labels for pods                                        |
+| image                         | icm-as image configuration                             |
+| dockerSecret                  | deployment of a docker registry secret                 |
+| imagePullSecrets              | image pull secrets                                     |
+| customizations                | customizations to be deployed                          |
+| jvm                           | icm-as jvm configuration                               |
+| newrelic                      | newrelic configuration                                 |
+| infrastructureMonitoring      | infrastructure monitoring configuration                |
+| operationalContext            | operational context configuration                      |
+| serviceAccount                | service account to be deployed                         |
+| podSecurityContext            | pod security context                                   |
+| dnsConfig                     | dns configuration                                      |
+| testConnection                | test connection configuration                          |
+| resources                     | resources / limits configuration                       |
+| database                      | database configuration                                 |
+| environment                   | environment variables                                  |
+| secrets                       | secrets to be made available as environment variables  |
+| [secretMounts](#secretMounts) | secrets to be mounted as files / environment variables |
+| persistence                   | persistence / volumes configuration                    |
+| probes                        | probes (startup, liveness, readiness) configuration    |
+| mssql                         | deployment of an MSSQL database inside a pod           |
+| copySitesDir                  | copy sites directory                                   |
+| ingress                       | ingress configuration                                  |
+| webLayer                      | web layer (webadapter-replacement) configuration       |
+| sslCertificateRetrieval       | ssl certificate retrieval                              |
+| job                           | job server configuration                               |
+| replication                   | replication/staging configuration                      |
+| jgroups                       | jgroups configuration                                  |
+| tolerations                   | pod tolerations configuration                          |
+
+# secretMounts
+
+> _@Since 2.9.0_
+
+## Description
+
+Allows to mount the content of Kubernetes secrets as files of make it available as environment variables to the `icm-as-server` container.
+The `secretMounts` section is a list of objects containing the following attributes:
+
+| Attribute  | Description                                                                              | Type                           | Mandatory/Optional             | Default Value                   |
+| ---------- | ---------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------ | ------------------------------- |
+| secretName | the name of the secret                                                                   | string                         | mandatory                      | -                               |
+| type       | the type of the secret                                                                   | enum {`secret`, `certificate`} | optional                       | `secret`                        |
+| key        | the data field inside the secret                                                         | string                         | optional if `type=certificate` | `tls.crt` if `type=certificate` |
+| targetFile | path relative to `/secrets` if `type=secret` resp. `/certificates` if `type=certificate` | path                           | optional                       | -                               |
+| targetEnv  | name of the environment variable to get made available                                   | string                         | optional                       | -                               |
+
+> **Attention**: If neither `targetFile` nor `targetEnv` is set, the `secretMounts`-entry will have no effect at all.
+
+> **Attention**: `certificate`s are imported into the truststore of the `icm-as-server`-container's JVM. So it is available to validate SSL/TLS connections to other servers that use this certificate.
+
+## Example
+
+```yaml
+secretMounts:
+  - secretName: my-secret
+    type: secret
+    targetFile: my-secret.txt
+  - secretName: my-certificate
+    type: certificate
+    key: tls.crt
+    targetFile: my-certificate-file.crt
+  - secretName: my-certificate
+    type: certificate
+    key: tls.key
+    targetFile: my-certificate-file.key
+  - secretName: my-secret2
+    type: secret
+    targetEnv: MY_SECRET2
+    targetFile: my-secret2.txt
+```
+
+- mounts the 3 secrets `my-secret`, `my-certificate` and `my-secret-env`:
+  - `my-secret` is mounted as file `/secrets/my-secret.txt`
+  - the certificate part of `my-certificate` is mounted as file `/certificates/my-certificate-file.crt`
+  - the private key part of `my-certificate` is mounted as file `/certificates/my-certificate-file.key`
+  - `my-secret2` is made available as environment variable `MY_SECRET2` and mounted as file `/secrets/my-secret2.txt`
+
+Minimal variation of the above example (omitting optional attributes):
+
+```yaml
+secretMounts:
+  - secretName: my-secret
+    targetFile: my-secret.txt
+  - secretName: my-certificate
+    type: certificate
+    targetFile: my-certificate-file.crt
+  - secretName: my-certificate
+    type: certificate
+    key: tls.key
+    targetFile: my-certificate-file.key
+  - secretName: my-secret2
+    targetEnv: MY_SECRET2
+    targetFile: my-secret2.txt
+```
+
+> **Note**: See [Guide - Secret Store Process](https://support.intershop.com/kb/index.php/Display/X31381) for details on how to make secrets and certificates from an Azure KeyVault available in K8s secrets.

--- a/charts/icm-as/templates/_helpers.tpl
+++ b/charts/icm-as/templates/_helpers.tpl
@@ -156,9 +156,6 @@ Image spec
 {{- define "icm-as.image" -}}
 image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
 imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-{{- if .Values.customCommand }}
-command: {{- toYaml .Values.customCommand | nindent 2 }}
-{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -4,7 +4,7 @@ Creates init-containers
 */}}
 {{- define "icm-as.initContainers" -}}
 initContainers:
-{{- if eq .Values.persistence.sites.type "local" }}
+{{- if eq .Values.persistence.sites.type "local_" }}
 # the following container
 # 1) only is active if local storage is enabled
 # 2) applies permission 777 to sites volume

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -45,4 +45,22 @@ volumeMounts:
 - mountPath: /mnt/secrets
   name: secrets-store-inline
 {{- end }}
-{{- end -}}
+{{- if .Values.secretMounts }}
+{{- range $index, $mount := .Values.secretMounts }}
+{{- $type := default "secret" $mount.type }}
+{{- $mountPath := "" }}
+{{- if $mount.targetFile }}
+{{- if eq $type "secret" }}
+  {{- $mountPath = "/secrets" }}
+{{- else if eq $type "certificate" }}
+  {{- $mountPath = "/certificates" }}
+{{- else }}
+  {{- fail (printf "Error: invalid value '%s' at secretMounts[%d].type, must be one of (secret,certificate), default=secret." $type $index) -}}
+{{- end }}
+- name: secretmount-{{ $index }}
+  mountPath: {{ $mountPath | quote }}
+  readOnly: true
+{{- end }} {{/*if $mount.targetFile*/}}
+{{- end }} {{/*range*/}}
+{{- end }} {{/*if .Values.secretMounts*/}}
+{{- end -}} {{/*define "icm-as.volumeMounts"*/}}

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -44,7 +44,27 @@ volumes:
     volumeAttributes:
       secretProviderClass: {{ include "icm-as.fullname" . }}-cert
 {{- end }}
-{{- end -}}
+{{- if .Values.secretMounts }}
+{{- range $index, $mount := .Values.secretMounts }}
+{{- $type := default "secret" $mount.type }}
+{{- $key := $mount.key }}
+{{- if eq $type "certificate" }}
+  {{- $key = default "tls.crt" $key }}
+{{- end }}
+{{- if not $key }}
+  {{- fail (printf "Error: missing value at secretMounts[%d].key" $index) -}}
+{{- end }}
+{{- if $mount.targetFile }}
+- name: secretmount-{{ $index }}
+  secret:
+    secretName: {{ $mount.secretName | quote }}
+    items:
+    - key: {{ $key | quote }}
+      path: {{ $mount.targetFile | quote }}
+{{- end }} {{/*if $mount.targetFile*/}}
+{{- end }} {{/*range*/}}
+{{- end }} {{/*if .Values.secretMounts*/}}
+{{- end -}} {{/*define "icm-as.volumes"*/}}
 
 {{/*
 Creates a volume named {$name}-volume

--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -58,6 +58,19 @@ spec:
       {{- end }}
       containers:
       - name: icm-as-server
+        {{- if .Values.customCommand }}
+        command: {{- toYaml .Values.customCommand | nindent 10 }}
+        {{- else }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            source /__cacert_entrypoint.sh && \
+            ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+            printf '%.0s-' {1..80} && \
+            echo && \
+            /intershop/bin/intershop.sh
+        {{- end }}
         {{- include "icm-as.image" . | nindent 8 }}
         {{- include "icm-as.envAS" . | nindent 8 }}
         {{- include "icm-as.ports" . | nindent 8 }}

--- a/charts/icm-as/templates/ssl-certificate-spc.yaml
+++ b/charts/icm-as/templates/ssl-certificate-spc.yaml
@@ -19,7 +19,7 @@ spec:
       key: tls.crt
   parameters:
     usePodIdentity: "true"                                                          # [OPTIONAL for Azure] if not provided, will default to "false"
-    tenantId: "{{ .Values.sslCertificateRetrieval.keyvault.tenantId }}"             # the tenant ID of the KeyVault
+    tenantId: "{{ .Values.sslCertificateRetrieval.keyvault.tenantId }}"             # the tenant ID / Directory ID of the KeyVault
     subscriptionId: "{{ .Values.sslCertificateRetrieval.keyvault.subscriptionId }}" # [REQUIRED for version < 0.0.4] the subscription ID of the KeyVault
     resourceGroup: "{{ .Values.sslCertificateRetrieval.keyvault.resourceGroup }}"   # [REQUIRED for version < 0.0.4] the resource group of the KeyVault
     keyvaultName: "{{ .Values.sslCertificateRetrieval.keyvault.keyvaultName }}"     # the name of the KeyVault

--- a/charts/icm-as/tests/custom-command_test.yaml
+++ b/charts/icm-as/tests/custom-command_test.yaml
@@ -11,8 +11,17 @@ tests:
       - ../values.yaml
     template: templates/as-deployment.yaml
     asserts:
-      - isNull:
+      - equal:
           path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - -c
+            - |
+              source /__cacert_entrypoint.sh && \
+              ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+              printf '%.0s-' {1..80} && \
+              echo && \
+              /intershop/bin/intershop.sh
 
   - it: customComamnd is empty
     release:
@@ -25,8 +34,17 @@ tests:
       customComamnd: []
     template: templates/as-deployment.yaml
     asserts:
-      - isNull:
+      - equal:
           path: spec.template.spec.containers[0].command
+          value:
+            - /bin/bash
+            - -c
+            - |
+              source /__cacert_entrypoint.sh && \
+              ADDITIONAL_JVM_ARGUMENTS="${ADDITIONAL_JVM_ARGUMENTS} ${JAVA_TOOL_OPTIONS}" && \
+              printf '%.0s-' {1..80} && \
+              echo && \
+              /intershop/bin/intershop.sh
 
   - it: customComamnd is provided
     release:

--- a/charts/icm-as/tests/customizations_test.yaml
+++ b/charts/icm-as/tests/customizations_test.yaml
@@ -13,12 +13,8 @@ tests:
       customizations: {}
     template: templates/as-deployment.yaml
     asserts:
-      - contains:
+      - isNullOrEmpty:
           path: spec.template.spec.initContainers
-          content:
-            name: sites-volume-mount-hack
-          count: 1
-          any: true
 
   - it: one customization with default pullPolicy
     release:

--- a/charts/icm-as/tests/secret-mounts_test.yaml
+++ b/charts/icm-as/tests/secret-mounts_test.yaml
@@ -1,0 +1,276 @@
+suite: tests the secretMounts section values
+templates:
+  - templates/as-deployment.yaml
+tests:
+  - it: happy path (secret + certificate)
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: mySecret
+          type: secret
+          key:  data
+          targetEnv: MY_SECRET
+        - secretName: myCert
+          type: certificate
+          key:  tls.crt
+          targetFile: custom-cert.crt
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "mySecret"
+                key: "data"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-1
+            mountPath: "/certificates"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-1
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"
+
+  - it: type defaults to 'secret'
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: mySecret
+          key:  data
+          targetEnv: MY_SECRET
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "mySecret"
+                key: "data"
+
+  - it: if type is 'certificate' then key defaults to 'tls.crt'
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: myCert
+          type: certificate
+          targetFile: custom-cert.crt
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-0
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"
+
+  - it: if type is 'secret' then key is mandatory
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: mySecret
+          type: secret
+          targetEnv: MY_SECRET
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: missing value at secretMounts[0].key"
+
+  - it: targetEnv and targetFile can be used together
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: myCert
+          type: certificate
+          key: tls.crt
+          targetFile: custom-cert.crt
+          targetEnv: CUSTOM_CERT
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_CERT
+            valueFrom:
+              secretKeyRef:
+                name: "myCert"
+                key: "tls.crt"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-0
+            mountPath: "/certificates"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-0
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"
+
+  - it: targetEnv and targetFile can both be omitted
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: myCert
+          type: certificate
+          key: tls.crt
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_CERT
+            valueFrom:
+              secretKeyRef:
+                name: "myCert"
+                key: "tls.crt"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-0
+            mountPath: "/certificates"
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-0
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"
+
+  - it: key is validated
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts:
+        - secretName: mySecret
+          type: wrongType
+          key:  data
+          targetEnv: MY_SECRET
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: invalid value 'wrongType' at secretMounts[0].type, must be one of (secret,certificate), default=secret."
+
+  - it: section secretMounts can be omitted
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_CERT
+            valueFrom:
+              secretKeyRef:
+                name: "myCert"
+                key: "tls.crt"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-0
+            mountPath: "/certificates"
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-0
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"
+
+  - it: section secretMounts can be empty
+    template: templates/as-deployment.yaml
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      secretMounts: []
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_CERT
+            valueFrom:
+              secretKeyRef:
+                name: "myCert"
+                key: "tls.crt"
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-0
+            mountPath: "/certificates"
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-0
+            secret:
+              secretName: "myCert"
+              items:
+              - key: "tls.crt"
+                path: "custom-cert.crt"

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -220,10 +220,28 @@ environment:
   CARTRIDGE_LIST: "ft_icm_as"
 
 # environment variable secrets to be propagated to the icm-as-container
-secrets:
+# @Deprecated since 2.9.0, replaced by secretMounts with targetEnv provided
+secrets: []
   # - env: <YOUR_MAIL_PASSWORD> # environment variable key
   #  name: <emailSecrets> # name of the secret, containing the referenced key
   #  key: <smtpPassword> # key within the secret
+
+# Configure the secret mounts for the ICM application server.
+# List 0..n secret mounts consisting of the following properties: secretName[, type][, key,][, targetFile][, targetEnv]
+# If more than one field has to be mounted from a single secret add multiple entries with the same secretName (different targetFile|targetEnv).
+# If targetFile is provided the secret's value will be mounted as a file
+# If targetEnv is provided the secret's value set a an environment variable
+# If neither targetFile nor targetEnv is provided the secret's value not be available
+# Secrets of type "certificate" are imported into the JVM's truststore
+# See https://support.intershop.com/kb/index.php/Display/X31381 for details on how to make secrets and certificates from an Azure KeyVault available in K8s secrets
+secretMounts: # array containing the secret mappings to be mounted
+  - secretName: <secretName> # name of the secret
+    type: secret # target type inside the ICM, supported values incl. mount path
+                      # secret (default) -> /secrets
+                      # certificate -> /certificates
+    key:  data # data field inside the secret, optional for type=certificate with default=tls.crt
+    targetFile: <releativeFileName> # path relative to the parent path defined by the type, optional, if ommited no file will be mounted
+    targetEnv: <ENV_VARIABLE_NAME> # name of the environment variable to be set, optional, if ommited no variable will be set
 
 persistence:
   sites:
@@ -443,6 +461,7 @@ webLayer:
     # Redisson client yaml config
     config: null
 
+# @Deprecated since 2.9.0, replaced by secretMounts
 sslCertificateRetrieval:
   enabled: false
   supportV1: false


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

custom TLS certificate can not be imported into the icm-as JVM's truststore

Issue Number: Closes #1001 

## What Is the New Behavior?

custom TLS certificate can be imported into the icm-as JVM's truststore

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
