### PR TITLE
fix(icm): prevent CVE-2025-1974 (#1006)

### DIFF
--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: file://../icm-web
     condition: icm-web.enabled
   - name: ingress-nginx
-    version: 4.11.1
+    version: 4.12.2
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
   - name: mailhog


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Feature

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

Vulnerabilities from CVE-2025-1974
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #1006

## What Is the New Behavior?

Peventing CVE-2025-1974 (https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/)

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No

