### PR TITLE
#1027: allow to mount more than 1 certificate

### DIFF
--- a/charts/icm-as/docs/how-to.asciidoc
+++ b/charts/icm-as/docs/how-to.asciidoc
@@ -1,25 +1,71 @@
-= Configuring Custom TLS Certificates and Deploying ICM with Replication
+= How To
 :icons: font
 
 == Make a Custom TLS Certificate Available to the `icm-as-appserver`-container's JVM
 
 . Follow the link to create a secret in the K8s cluster using a certificate stored inside an Azure Key Vault: https://support.intershop.com/kb/index.php/Display/X31381[Guide - Secret Store Process].
+The definition of the `SecretProviderClass` would then look like:
++
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: csi-${namespace}-secret-store <1>
+  namespace: ${namespace} <2>
+spec:
+  provider: azure
+  parameters:
+    tenantId: "${secret_store_tenant_id}" <3>
+    keyvaultName: "${secret_store_keyvault_name}" <4>
+    clientID: "${secret_store_client_id}" <5>
+
+    # Objects to map from the Key Vault into Kubernetes secrets
+    objects: |
+      array:
+        - |
+          objectName: nameOfTheKeyvaultCertificate <6>
+          objectType: secret <7>
+          objectVersion: "" <8>
+
+  secretObjects: # Mapping of Key Vault objects into Kubernetes secrets
+    - secretName: nameOfTheK8sSecret <9>
+      type: Opaque
+      data:
+        - objectName: nameOfTheKeyvaultCertificate <10>
+          key: value
+----
++
+<1> variable `namespace` is provided by the namespace preparation as a config map entry
+<2> variable `namespace` is provided by the namespace preparation as a config map entry
+<3> directory id of the Azure EntryID tenant the Key Vault belongs to (provided by the namespace preparation as a config map entry)
+<4> name of the Key Vault (provided by the namespace preparation as a config map entry)
+<5> ID of the managed identity (provided by the namespace preparation as a config map entry)
+<6> name of the certificate inside the Key Vault
+<7> name of the certificate inside the Key Vault (same as 6)
+<8> always leave empty
+<9> name of the Kubernetes secret to be created
+<10> name of the certificate inside the Key Vault (same as 6)
+
+
 . Add an entry inside the link:values-yaml/secret-mounts.asciidoc[secretMounts] section:
 
-   * Reference the secret created following the guide from step 1.
-   * Set `type` to `certificate`.
-   * Set `key` to `tls.crt` or omit the `key`.
+   * Reference the secret created following the guide from step 1
+   * Set `type` to `certificate`
+   * Set `key` to `tls.crt` or omit the `key`
    * Set `targetFile` to a valid file name using the file extension `.crt`
 
++
 [source,yaml]
 ----
 secretMounts:
-  - secretName: nameOfTheSecret
+  - secretName: nameOfTheK8sSecret
     type: certificate
     key: tls.crt
     targetFile: my-certificate-file.crt
 ----
 
++
 [NOTE]
 ====
 The certificate will then be imported into the truststore of the JVM using the alias built from the base file name `my-certificate-file`.

--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -138,12 +138,12 @@ Creates the environment secretMounts section
 {{- if and (eq $mount.type "certificate") ($mount.targetFile) }}
   {{- $secretMountsRequireCertImport = true -}}
 {{- end -}}
+{{- end -}} {{/*range $index, $mount := .Values.secretMounts*/}}
 {{- if eq $secretMountsRequireCertImport true }}
 - name: USE_SYSTEM_CA_CERTS
   value: "1"
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end -}} {{/*if eq $secretMountsRequireCertImport true*/}}
+{{- end -}} {{/*define "icm-as.envSecretMounts"*/}}
 
 {{/*
 Creates the environment replication section

--- a/charts/icm-as/templates/_volumeMounts.tpl
+++ b/charts/icm-as/templates/_volumeMounts.tpl
@@ -51,14 +51,15 @@ volumeMounts:
 {{- $mountPath := "" }}
 {{- if $mount.targetFile }}
 {{- if eq $type "secret" }}
-  {{- $mountPath = "/secrets" }}
+  {{- $mountPath = printf "/secrets/%s" $mount.targetFile }}
 {{- else if eq $type "certificate" }}
-  {{- $mountPath = "/certificates" }}
+  {{- $mountPath = printf "/certificates/%s" $mount.targetFile }}
 {{- else }}
   {{- fail (printf "Error: invalid value '%s' at secretMounts[%d].type, must be one of (secret,certificate), default=secret." $type $index) -}}
 {{- end }}
 - name: secretmount-{{ $index }}
   mountPath: {{ $mountPath | quote }}
+  subPath: {{ $mount.targetFile | quote }}
   readOnly: true
 {{- end }} {{/*if $mount.targetFile*/}}
 {{- end }} {{/*range*/}}

--- a/charts/icm-as/tests/secret-mounts_test.yaml
+++ b/charts/icm-as/tests/secret-mounts_test.yaml
@@ -14,12 +14,16 @@ tests:
       secretMounts:
         - secretName: mySecret
           type: secret
-          key:  data
+          key: data
           targetEnv: MY_SECRET
         - secretName: myCert
           type: certificate
-          key:  tls.crt
+          key: tls.crt
           targetFile: custom-cert.crt
+        - secretName: myCert2
+          type: certificate
+          key: tls.crt
+          targetFile: custom-cert2.crt
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -33,7 +37,15 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: secretmount-1
-            mountPath: "/certificates"
+            mountPath: "/certificates/custom-cert.crt"
+            subPath: "custom-cert.crt"
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: secretmount-2
+            mountPath: "/certificates/custom-cert2.crt"
+            subPath: "custom-cert2.crt"
             readOnly: true
       - contains:
           path: spec.template.spec.volumes
@@ -42,8 +54,17 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: secretmount-2
+            secret:
+              secretName: "myCert2"
+              items:
+                - key: "tls.crt"
+                  path: "custom-cert2.crt"
 
   - it: type defaults to 'secret'
     template: templates/as-deployment.yaml
@@ -56,7 +77,7 @@ tests:
     set:
       secretMounts:
         - secretName: mySecret
-          key:  data
+          key: data
           targetEnv: MY_SECRET
     asserts:
       - contains:
@@ -89,8 +110,8 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"
 
   - it: if type is 'secret' then key is mandatory
     template: templates/as-deployment.yaml
@@ -137,7 +158,8 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: secretmount-0
-            mountPath: "/certificates"
+            mountPath: "/certificates/custom-cert.crt"
+            subPath: "custom-cert.crt"
             readOnly: true
       - contains:
           path: spec.template.spec.volumes
@@ -146,8 +168,8 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"
 
   - it: targetEnv and targetFile can both be omitted
     template: templates/as-deployment.yaml
@@ -184,8 +206,8 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"
 
   - it: key is validated
     template: templates/as-deployment.yaml
@@ -199,7 +221,7 @@ tests:
       secretMounts:
         - secretName: mySecret
           type: wrongType
-          key:  data
+          key: data
           targetEnv: MY_SECRET
     asserts:
       - failedTemplate:
@@ -237,8 +259,8 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"
 
   - it: section secretMounts can be empty
     template: templates/as-deployment.yaml
@@ -272,5 +294,5 @@ tests:
             secret:
               secretName: "myCert"
               items:
-              - key: "tls.crt"
-                path: "custom-cert.crt"
+                - key: "tls.crt"
+                  path: "custom-cert.crt"


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #1027

## What Is the New Behavior?

More than 1 certificate / secret can be mounted

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

## Other Information

Documentation improved