### PR TITLE
fix(icm): allow to mount more than 1 certificate (#1027)

### DIFF
--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -36,10 +36,10 @@ image:
 
 ## define a secret for a container registry
 dockerSecret:
-  enabled: true
+  enabled: false
   name: "dockerhub"
-  username: "kiese"
-  password: "kiesepw"
+  username: "<your registry username>"
+  password: "<your registry password>"
 
 ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace
 ## or by the above dockerSecrets section.


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## What Is the Current Behavior?

Issue Number: Closes #1027 

## What Is the New Behavior?

more than 1 certificate can be mounted

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No