### PR TITLE
feat: documentation of environmentName

### DIFF
--- a/charts/icm-as/docs/values-yaml/operational-context.asciidoc
+++ b/charts/icm-as/docs/values-yaml/operational-context.asciidoc
@@ -15,7 +15,15 @@ Configures the operational context (aka _environment_) the ICM is running in. Th
 |Attribute |Description |Type |Mandatory |Default Value
 |customerId|the id of the customer|string|{mandatory}|`n_a` (default value for compatibility with older versions)
 |environmentType|the type of the environment e.g.int,uat,prd|string|{optional}|`prd`
-|environmentName|the name of the environment (environment-type + some sort of id, e.g. int-01)|string|{optional}|[.placeholder]#value of `environmentType`#
+|environmentName|defines the system enviromnent variable "ENVIRONMENT",
+(see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
+
+Proposed values:
+
+* development   (for local dev systems)
+* integration   (for all systems with environmentType: int)
+* preproduction (for all systems with environmentType: uat)
+* production    (for all systems with environmentType: prd)|string|{optional}|[.placeholder]#value of `environmentType`#
 |===
 
 Using these attribute and some additional information from section link:replication.asciidoc[`replication`] the `operationalContextName` is calculated as follows:

--- a/charts/icm-as/docs/values-yaml/operational-context.asciidoc
+++ b/charts/icm-as/docs/values-yaml/operational-context.asciidoc
@@ -15,7 +15,7 @@ Configures the operational context (aka _environment_) the ICM is running in. Th
 |Attribute |Description |Type |Mandatory |Default Value
 |customerId|the id of the customer|string|{mandatory}|`n_a` (default value for compatibility with older versions)
 |environmentType|the type of the environment e.g.int,uat,prd|string|{optional}|`prd`
-|environmentName|defines the system enviromnent variable "ENVIRONMENT",
+|environmentName|defines the system environment variable "ENVIRONMENT",
 (see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
 
 Proposed values:

--- a/charts/icm-as/tests/default-values_test.yaml
+++ b/charts/icm-as/tests/default-values_test.yaml
@@ -26,10 +26,10 @@ tests:
           value: icm-as-0.8.15
       - equal:
           path: metadata.labels.environment-name
-          value: prd
+          value: production
       - equal:
           path: metadata.labels.operational-context
-          value: n_a-prd-standalone
+          value: n_a-production-standalone
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: icm-as
@@ -74,7 +74,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ENVIRONMENT
-            value: "prd"
+            value: "production"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/icm-as/tests/environment_test.yaml
+++ b/charts/icm-as/tests/environment_test.yaml
@@ -15,7 +15,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ENVIRONMENT
-            value: "prd"
+            value: "production"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -68,7 +68,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ENVIRONMENT
-            value: "prd"
+            value: "production"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -187,7 +187,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: ENVIRONMENT
-            value: "prd"
+            value: "production"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/icm-as/tests/newrelic_test.yaml
+++ b/charts/icm-as/tests/newrelic_test.yaml
@@ -169,7 +169,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data["newrelic.yml"]
-          pattern: '.*(app_name: "n_a-prd-standalone-icm-as").*'
+          pattern: '.*(app_name: "n_a-production-standalone-icm-as").*'
   - it: newrelic log metrics (on)
     release:
       name: icm-as

--- a/charts/icm-as/tests/operational_context_test.yaml
+++ b/charts/icm-as/tests/operational_context_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels.operational-context
-          value: "n_a-prd-standalone"
+          value: "n_a-production-standalone"
 
   - it: replication operational context (edit)
     release:

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -152,8 +152,14 @@ operationalContext:
   customerId: "n_a"
   # type of the environment (one of {int,uat,prd}, default=prd)
   environmentType: prd
-  # name of the environment (environment-type + some sort of id, e.g. int-01, default=<environmentType>)
-  environmentName: prd
+  # defines the system enviromnent variable "ENVIRONMENT",
+  # (see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
+  # Proposed values:
+  # * development   (for local dev systems)
+  # * integration   (for all systems with environmentType: int)
+  # * preproduction (for all systems with environmentType: uat)
+  # * production    (for all systems with environmentType: prd)
+  environmentName: production
 
 serviceAccount:
   # Specifies whether a service account should be created and used

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -152,7 +152,7 @@ operationalContext:
   customerId: "n_a"
   # type of the environment (one of {int,uat,prd}, default=prd)
   environmentType: prd
-  # defines the system enviromnent variable "ENVIRONMENT",
+  # defines the system environment variable "ENVIRONMENT",
   # (see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
   # Proposed values:
   # * development   (for local dev systems)

--- a/charts/icm-web/tests/operational_context_test.yaml
+++ b/charts/icm-web/tests/operational_context_test.yaml
@@ -16,7 +16,7 @@ tests:
     asserts:
       - equal:
           path: metadata.labels.operational-context
-          value: "n_a-prd-standalone"
+          value: "n_a-production-standalone"
       - equal:
           path: metadata.labels.environment-type
           value: "prd"

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -12,8 +12,14 @@ operationalContext:
   customerId: "n_a"
   # type of the environment (one of {int,uat,prd}, default=prd)
   environmentType: prd
-  # name of the environment (environment-type + some sort of id, e.g. int-01, default=<environmentType>)
-  environmentName: prd
+  # defines the system enviromnent variable "ENVIRONMENT",
+  # (see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
+  # Proposed values:
+  # * development   (for local dev systems)
+  # * integration   (for all systems with environmentType: int)
+  # * preproduction (for all systems with environmentType: uat)
+  # * production    (for all systems with environmentType: prd)
+  environmentName: production
   # if this is a staging environment define the system type (one of {standalone,live,edit}, default=standalone)
   stagingType: standalone
 

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -12,7 +12,7 @@ operationalContext:
   customerId: "n_a"
   # type of the environment (one of {int,uat,prd}, default=prd)
   environmentType: prd
-  # defines the system enviromnent variable "ENVIRONMENT",
+  # defines the system environment variable "ENVIRONMENT",
   # (see SMC, Monitoring > Application Server > Configuration Values, scope: cluster, key "environment")
   # Proposed values:
   # * development   (for local dev systems)


### PR DESCRIPTION
feat: documentation of environmentName

Documentation of operationalContext:environmentName (used by icm-as as well as icm-web) was not good for ICM developers.
The environmentName is mapped to key "environment" in the ICM cluster configuration, which is already used by nearly all ICM projects, expecting values "development", "integration", "preproduction", "production" in nearly all projects! (These values are already hard-coded into many e.g. configuration files like "integration_editing_appserver.properties".)

Another topic and explanation from ICM project point of view:
"environmentName" is mapped to ICM app server system environment variable "ENVIRONMENT".
It would be good to also map the "environmentType" to an ICM app server system environment variable.
Because then we would have an environment type as well as an environment name in the ICM cluster configuration.
For now, it is much more important to have the environment type ("development", "integration", "preproduction", "production") in the ICM cluster configuration than to have the environment name available. That's why we have to code an environment type into "environmentName"!

<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [x] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #

## What Is the New Behavior?

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information
