### PR TITLE
fix(icm): jobserver needs jgroups (#1059)

### DIFF
--- a/charts/icm-job-test/values-iste_linux.tmpl
+++ b/charts/icm-job-test/values-iste_linux.tmpl
@@ -62,12 +62,21 @@ icm:
       MAIL_SMTP_PORT: "1025"
       MAIL_CLIENT_API_PORT: "8025"
       MAIL_SMTP_MAILHOG_ENABLED: "true"
+
+      CLUSTERID: "fae2f48e6be649e7b88f8c096d9ba054"
     persistence:
       sites:
         size: 2Gi
         type: cluster
         cluster:
           storageClass:
+            existingClass: azurefile
+      jgroups:
+        size: 1Gi
+        type: cluster
+        cluster:
+          storageClass:
+            create: false
             existingClass: azurefile
       encryption:
         type: emptyDir


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

JobServer tests fail maybe due to missing jgroups configuration

Issue Number: Closes #1059

## What Is the New Behavior?

jgroups is configured

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

