### PR TITLE
feature/icm/1070 consume newest webadapter

### DIFF
--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -19,7 +19,7 @@ operationalContext:
 
 webadapter:
   image:
-    repository: intershophub/icm-webadapter:2.6.0
+    repository: intershophub/icm-webadapter:2.7.0
     pullPolicy: IfNotPresent
   # disable HTTP/2 protocol support if required
   disableHTTP2: false


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Issue Number: Closes #1070 
intershophub/icm-webadapter:2.6.0 is consumed (does not compress responses)

## What Is the New Behavior?

intershophub/icm-webadapter:2.7.0 is consumed (compresses responses if required)

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

