### PR TITLE
feat(icm): new operator image has no kube-rbac-proxy anymore (#1203)

### DIFF
--- a/charts/icm-job/templates/icm-job.yaml
+++ b/charts/icm-job/templates/icm-job.yaml
@@ -117,44 +117,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: project
   name: icm-metrics-reader
 rules:
 - nonResourceURLs:
-  - /metrics
+  - "/metrics"
   verbs:
   - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/instance: proxy-role
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: project
-  name: icm-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -198,18 +166,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/instance: proxy-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: project
-  name: icm-proxy-rolebinding
+  name: icm-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: icm-proxy-role
+  name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
   name: icm-controller-manager
@@ -219,20 +180,20 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/instance: controller-manager-metrics-service
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: project
     control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/part-of: project
+    app.kubernetes.io/managed-by: kustomize
   name: icm-controller-manager-metrics-service
 spec:
   ports:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   selector:
     control-plane: controller-manager
 ---
@@ -280,44 +241,30 @@ spec:
         {{- include "imagePullSecrets" . | nindent 6 }}
       {{- end }}
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8443
+        image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
+        imagePullPolicy: {{ .Values.image.imagePullPolicy | default "IfNotPresent"}}
+        name: manager
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
-        command:
-        - /manager
-        image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
-        imagePullPolicy: {{ .Values.image.imagePullPolicy | default "IfNotPresent"}}
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
         readinessProbe:
           httpGet:
             path: /readyz
@@ -331,11 +278,6 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
       securityContext:
         runAsNonRoot: true
       serviceAccountName: icm-controller-manager

--- a/charts/icm-job/templates/icm-job.yaml
+++ b/charts/icm-job/templates/icm-job.yaml
@@ -66,7 +66,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: project
   name: icm-manager-role
 rules:
 - apiGroups:
@@ -117,6 +123,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: project
   name: icm-metrics-reader
 rules:
 - nonResourceURLs:
@@ -166,6 +179,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/instance: metrics-auth-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: project
   name: icm-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -247,7 +267,14 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
-        image: "{{ .Values.image.repository }}{{ if not (contains ":" .Values.image.repository) }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
+        {{- $repository := .Values.image.repository -}}
+        {{- $tag := (.Values.image.tag | default .Chart.AppVersion) -}}
+        {{- $imageName := (splitList "/" $repository | last) -}}
+        {{- if contains ":" $imageName }}
+        image: "{{ $repository }}"
+        {{- else }}
+        image: "{{ $repository }}:{{ $tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.imagePullPolicy | default "IfNotPresent"}}
         name: manager
         securityContext:

--- a/charts/icm-job/values.yaml
+++ b/charts/icm-job/values.yaml
@@ -13,6 +13,6 @@ imagePullSecrets:
 - "dockerhub"
 
 image:
-  repository: intershophub/icm-job-operator:1.0.1
+  repository: intershophub/icm-job-operator:2.0.0
   # Optional option to override the default (IfNotPresent) https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
   # imagePullPolicy: Never

--- a/charts/icm-job/values.yaml
+++ b/charts/icm-job/values.yaml
@@ -13,6 +13,6 @@ imagePullSecrets:
 - "dockerhub"
 
 image:
-  repository: intershophub/icm-job-operator:2.0.0
+  repository: intershophub/icm-job-operator:2.1.0
   # Optional option to override the default (IfNotPresent) https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
   # imagePullPolicy: Never


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [x] Feature

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

The used kube-rbac-proxy was used to protect the metrics endpoint. The used image wasn't available anymore and is also deprecated. The new image now uses features of a new controller-runtime.

Issue Number: Closes #1203

## What Is the New Behavior?

The new image is used without any kube-rbac-proxy dependencies and resources.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes

