### PR TITLE
fix (icm): add missing label to jobserver pods (#1206)

### DIFF
--- a/charts/icm-as/templates/jobserver-deployment.yaml
+++ b/charts/icm-as/templates/jobserver-deployment.yaml
@@ -26,6 +26,9 @@ metadata:
     {{- if include "icm-as.podBinding" $jobValues }}
       {{- include "icm-as.podBinding" $jobValues | nindent 8 }}
     {{- end }}
+    {{- if include "icm-as.serviceAccount.podLabels" $jobValues -}}
+      {{- include "icm-as.serviceAccount.podLabels" $jobValues | nindent 4 }}
+    {{- end }}
 spec:
   scheduleTimeComputer: {{ include "icm-as.scheduleTimeComputer" $jobValues -}}
   {{- if .Values.job.suspend }}

--- a/charts/icm-as/tests/serviceaccount-workloadidentity_test.yaml
+++ b/charts/icm-as/tests/serviceaccount-workloadidentity_test.yaml
@@ -378,6 +378,9 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.metadata.labels["azure.workload.identity/use"]
           value: "true"
+      - equal:
+          path: metadata.labels["azure.workload.identity/use"]
+          value: "true"
 
   # Test 20: Combined scenario - serviceAccount.create and workloadIdentity both enabled
   - it: should work correctly when both serviceAccount.create and workloadIdentity are enabled


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Label relevant for workloadIdentity is missing.

Issue Number: Closes #1206

## What Is the New Behavior?

Label relevant for workloadIdentity exists.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
