### PR TITLE
feat(icm): enable automatic database restore for local execution (#1205)

### DIFF
--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -68,4 +68,66 @@ initContainers:
     name: customizations-volume
 {{- end }}
 {{- end }}
+{{- if and .Values.mssql.enabled .Values.dumpfileRestore.enabled }}
+- name: db-restore-from-dumpfile
+  image: "{{ .Values.dumpfileRestore.image.repository }}"
+  imagePullPolicy: IfNotPresent
+  command:
+  - "/bin/bash"
+  - "-c"
+  - |
+    set -e
+    DUMPFILE_DIR="{{ .Values.dumpfileRestore.dumpfileDir }}"
+    if [ ! -d "$DUMPFILE_DIR" ]; then
+      echo "Dumpfile directory $DUMPFILE_DIR does not exist, skipping restore."
+      exit 0
+    fi
+    DUMPFILE=$(find "$DUMPFILE_DIR" -maxdepth 1 \( -name "*.dmp" -o -name "*.bak" \) 2>/dev/null | head -1)
+    if [ -z "$DUMPFILE" ]; then
+      echo "No dumpfile found in $DUMPFILE_DIR, skipping restore."
+      exit 0
+    fi
+    echo "Found dumpfile: $DUMPFILE"
+    FILENAME=$(basename "$DUMPFILE")
+    echo "Copying dumpfile to MSSQL backup volume..."
+    cp "$DUMPFILE" /mssql-backup/
+    echo "Dumpfile copied successfully."
+    MSSQL_HOST="{{ include "icm-as.fullname" . }}-mssql-service"
+    SA_PASSWORD="{{ .Values.mssql.saPassword }}"
+    DB_NAME="{{ .Values.mssql.databaseName }}"
+    echo "Waiting for MSSQL at $MSSQL_HOST to be ready..."
+    for i in $(seq 1 {{ .Values.dumpfileRestore.waitTimeout }}); do
+      /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "SELECT 1" > /dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        echo "MSSQL is ready after ${i}s."
+        break
+      fi
+      if [ "$i" -eq {{ .Values.dumpfileRestore.waitTimeout }} ]; then
+        echo "ERROR: MSSQL did not become ready within {{ .Values.dumpfileRestore.waitTimeout }}s."
+        exit 1
+      fi
+      sleep 1
+    done
+    echo "Restoring database '$DB_NAME' from /var/opt/mssql/backup/$FILENAME..."
+    /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "RESTORE DATABASE [$DB_NAME] FROM DISK = N'/var/opt/mssql/backup/$FILENAME' WITH REPLACE"
+    if [ $? -eq 0 ]; then
+      echo "Database restore completed successfully."
+      DB_USER="{{ .Values.mssql.user }}"
+      DB_PASSWORD="{{ .Values.mssql.password }}"
+      echo "Fixing database user mapping for $DB_USER..."
+      /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "USE [$DB_NAME]; IF NOT EXISTS (SELECT name FROM master.sys.server_principals WHERE name = '$DB_USER') BEGIN CREATE LOGIN [$DB_USER] WITH PASSWORD = '$DB_PASSWORD', CHECK_POLICY = OFF END; IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = '$DB_USER') BEGIN CREATE USER [$DB_USER] FOR LOGIN [$DB_USER] END ELSE BEGIN ALTER USER [$DB_USER] WITH LOGIN = [$DB_USER] END; ALTER ROLE [db_owner] ADD MEMBER [$DB_USER];"
+    else
+      echo "ERROR: Database restore failed."
+      exit 1
+    fi
+  volumeMounts:
+  {{- if .Values.persistence.customdata.enabled }}
+  - name: custom-data-volume
+    mountPath: {{ .Values.persistence.customdata.mountPoint | default "/data" }}
+  {{- end }}
+  - name: mssql-backup-volume
+    mountPath: /mssql-backup
+  securityContext:
+    runAsUser: 0
+{{- end }}
 {{- end -}}

--- a/charts/icm-as/templates/_initContainer.tpl
+++ b/charts/icm-as/templates/_initContainer.tpl
@@ -97,8 +97,7 @@ initContainers:
     DB_NAME="{{ .Values.mssql.databaseName }}"
     echo "Waiting for MSSQL at $MSSQL_HOST to be ready..."
     for i in $(seq 1 {{ .Values.dumpfileRestore.waitTimeout }}); do
-      /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "SELECT 1" > /dev/null 2>&1
-      if [ $? -eq 0 ]; then
+      if /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "SELECT 1" > /dev/null 2>&1; then
         echo "MSSQL is ready after ${i}s."
         break
       fi

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -36,6 +36,22 @@ volumes:
 {{- end }}
 - name: customizations-volume
   emptyDir: {}
+{{- if and .Values.mssql.enabled .Values.dumpfileRestore.enabled }}
+- name: mssql-backup-volume
+{{- if eq .Values.mssql.persistence.backup.type "local" }}
+  persistentVolumeClaim:
+    claimName: "{{ template "icm-as.fullname" . }}-local-mssql-db-backup-pvc"
+{{- else if eq .Values.mssql.persistence.backup.type "existingClaim" }}
+  persistentVolumeClaim:
+    claimName: "{{ .Values.mssql.persistence.backup.existingClaim }}"
+{{- else if eq .Values.mssql.persistence.backup.type "nfs" }}
+  persistentVolumeClaim:
+    claimName: "{{ template "icm-as.fullname" . }}-nfs-mssql-db-backup-pvc"
+{{- else if eq .Values.mssql.persistence.backup.type "cluster" }}
+  persistentVolumeClaim:
+    claimName: "{{ template "icm-as.fullname" . }}-cluster-mssql-db-backup-pvc"
+{{- end }}
+{{- end }}
 {{- if .Values.sslCertificateRetrieval.enabled }}
 - name: secrets-store-inline
   csi:

--- a/charts/icm-as/templates/_volumes.tpl
+++ b/charts/icm-as/templates/_volumes.tpl
@@ -44,12 +44,19 @@ volumes:
 {{- else if eq .Values.mssql.persistence.backup.type "existingClaim" }}
   persistentVolumeClaim:
     claimName: "{{ .Values.mssql.persistence.backup.existingClaim }}"
+{{- else if eq .Values.mssql.persistence.backup.type "azurefiles" }}
+  azureFile:
+    secretName: {{ .Values.mssql.persistence.backup.azurefiles.secretName }}
+    shareName: {{ .Values.mssql.persistence.backup.azurefiles.shareName }}
+    readOnly: false
 {{- else if eq .Values.mssql.persistence.backup.type "nfs" }}
   persistentVolumeClaim:
     claimName: "{{ template "icm-as.fullname" . }}-nfs-mssql-db-backup-pvc"
 {{- else if eq .Values.mssql.persistence.backup.type "cluster" }}
   persistentVolumeClaim:
     claimName: "{{ template "icm-as.fullname" . }}-cluster-mssql-db-backup-pvc"
+{{- else }}
+  {{- fail (printf "Unsupported mssql.persistence.backup.type: %s (supported: local, existingClaim, azurefiles, nfs, cluster)" .Values.mssql.persistence.backup.type) }}
 {{- end }}
 {{- end }}
 {{- if .Values.sslCertificateRetrieval.enabled }}

--- a/charts/icm-as/tests/dumpfile-restore_test.yaml
+++ b/charts/icm-as/tests/dumpfile-restore_test.yaml
@@ -1,0 +1,234 @@
+suite: tests dumpfileRestore init-container and mssql-backup-volume
+templates:
+  - templates/as-deployment.yaml
+tests:
+  # ------------------------------------------------------------------
+  # Default: dumpfileRestore is disabled → init-container & volume absent
+  # ------------------------------------------------------------------
+  - it: db-restore-from-dumpfile init-container is absent by default
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: db-restore-from-dumpfile
+          any: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+          any: true
+
+  # ------------------------------------------------------------------
+  # dumpfileRestore.enabled but mssql.enabled=false → absent
+  # ------------------------------------------------------------------
+  - it: db-restore-from-dumpfile is absent when mssql is disabled
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: false
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: db-restore-from-dumpfile
+          any: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+          any: true
+
+  # ------------------------------------------------------------------
+  # type=local (default)
+  # ------------------------------------------------------------------
+  - it: renders mssql-backup-volume with type=local
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: local
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: db-restore-from-dumpfile
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            persistentVolumeClaim:
+              claimName: "icm-as-local-mssql-db-backup-pvc"
+
+  # ------------------------------------------------------------------
+  # type=existingClaim
+  # ------------------------------------------------------------------
+  - it: renders mssql-backup-volume with type=existingClaim
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: existingClaim
+      mssql.persistence.backup.existingClaim: my-existing-claim
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            persistentVolumeClaim:
+              claimName: "my-existing-claim"
+
+  # ------------------------------------------------------------------
+  # type=azurefiles
+  # ------------------------------------------------------------------
+  - it: renders mssql-backup-volume with type=azurefiles
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: azurefiles
+      mssql.persistence.backup.azurefiles.shareName: backup-share
+      mssql.persistence.backup.azurefiles.secretName: backup-secret
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            azureFile:
+              secretName: backup-secret
+              shareName: backup-share
+              readOnly: false
+
+  # ------------------------------------------------------------------
+  # type=nfs
+  # ------------------------------------------------------------------
+  - it: renders mssql-backup-volume with type=nfs
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: nfs
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            persistentVolumeClaim:
+              claimName: "icm-as-nfs-mssql-db-backup-pvc"
+
+  # ------------------------------------------------------------------
+  # type=cluster
+  # ------------------------------------------------------------------
+  - it: renders mssql-backup-volume with type=cluster
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: cluster
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            persistentVolumeClaim:
+              claimName: "icm-as-cluster-mssql-db-backup-pvc"
+
+  # ------------------------------------------------------------------
+  # unknown type → fail fast
+  # ------------------------------------------------------------------
+  - it: fails on unknown mssql.persistence.backup.type
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      mssql.persistence.backup.type: bogus
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - failedTemplate:
+          errorMessage: "Unsupported mssql.persistence.backup.type: bogus (supported: local, existingClaim, azurefiles, nfs, cluster)"
+
+  # ------------------------------------------------------------------
+  # volumeMount on the init-container
+  # ------------------------------------------------------------------
+  - it: db-restore-from-dumpfile mounts mssql-backup-volume at /mssql-backup
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      mssql.enabled: true
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /dumps
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: db-restore-from-dumpfile
+          any: true

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -453,6 +453,16 @@ mssql:
       local:
         path: <local mssql backup folder>
 
+# Restore database from a dump file found in a dumpfile directory
+dumpfileRestore:
+  enabled: false
+  # Path to directory containing the .dmp or .bak file
+  dumpfileDir: <dumpfile directory>
+  image:
+    repository: <repository for restore job>
+  # Max seconds to wait for MSSQL to become ready
+  waitTimeout: <timeout for MSSQL readiness>
+
 # allows it to copy the sites dir which is needed for our test execution
 copySitesDir:
   enabled: false

--- a/charts/icm-test/docs/local-execution.asciidoc
+++ b/charts/icm-test/docs/local-execution.asciidoc
@@ -12,7 +12,7 @@ This document describes how to run the ICM Test Chart locally using Docker Deskt
 
 === 1. Switch kubectl context to local Docker
 
-Start Docker Desktop and ensure it is running with Kubernetes. Then, switch your kubectl context to Docker Desktop using the following command.
+Start Docker Desktop and ensure it is running with Kubernetes. It is recommended to use kubeadm as the cluster type. Then, switch your kubectl context to Docker Desktop using the following command.
 
 [source,bash]
 ----

--- a/charts/icm-test/docs/local-execution.asciidoc
+++ b/charts/icm-test/docs/local-execution.asciidoc
@@ -88,7 +88,7 @@ You can now run the `start-test-local.sh` script using `./start-test-local.sh`. 
 . Helm Chart Name: The name of the helm chart as you want to release it. This MUST match the name you set earlier in the hosts file (Step 6).
 . Testsuite: The name of the testsuite you want to run.
 . Test image: The image you want to run your test on. You can either use the default or specify your own. You can get possible images from the ISTE or from Dockerhub. In ISTE: Open the files of a testplan and look for a file called `helm_install_vars.sh`. In there you will find a field called `ICM_TEST_IMAGE`. This is the image name you need to use here.
-. Base path of your local folder mount: This is the path to the persistent volume directories you created earlier.
+. Base path of your local folder mount: This is the path to the persistent volume directories you created earlier. Note: Due to the way local folders are mounted into the docker desktop kubernetes cluster, the path needs to be in the format `/run/desktop/mnt/host/<your_path>`.
 . The pull secret for the icm-as+testrunner image: This is the pull secret from where you want to pull the test image. With default naming conventions this should be `dockerhub`. If you want to pull your image from the azure container registry, this secret needs to be `icmbuildsnapshot`.
 . The pull secret for the icm-wa+waa image: This is the pull secret for Docker Hub. With default naming conventions this should be `dockerhub`.
 

--- a/charts/icm-test/docs/local-execution.asciidoc
+++ b/charts/icm-test/docs/local-execution.asciidoc
@@ -90,6 +90,7 @@ You can now run the `start-test-local.sh` script using `./start-test-local.sh`. 
 . Test image: The image you want to run your test on. You can either use the default or specify your own. You can get possible images from the ISTE or from Dockerhub. In ISTE: Open the files of a testplan and look for a file called `helm_install_vars.sh`. In there you will find a field called `ICM_TEST_IMAGE`. This is the image name you need to use here.
 . Base path of your local folder mount: This is the path to the persistent volume directories you created earlier. Note: Due to the way local folders are mounted into the docker desktop kubernetes cluster, the path needs to be in the format `/run/desktop/mnt/host/<your_path>`.
 . The pull secret for the icm-as+testrunner image: This is the pull secret from where you want to pull the test image. With default naming conventions this should be `dockerhub`. If you want to pull your image from the azure container registry, this secret needs to be `icmbuildsnapshot`.
+. The pull secret for the MSSQL image: This is the pull secret used to pull the MSSQL database image. With default naming conventions this should be `dockerhub`.
 . The pull secret for the icm-wa+waa image: This is the pull secret for Docker Hub. With default naming conventions this should be `dockerhub`.
 
 The script will also verify if you have correctly configured the kubernetes secrets.

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -31,6 +31,7 @@ fi
 
 read -e -p 'Base path of your local folder mount: ' -i '/run/desktop/mnt/host/d/tmp/pv' LOCAL_MOUNT_BASE
 read -e -p 'The pull secret for the icm-as+testrunner image (e.g. dockerhub or icmbuildsnapshot): ' -i 'dockerhub' ICM_AS_PULL_SECRET
+read -e -p 'The pull secret for the mssql image (e.g dockerhub): ' -i 'dockerhub' MSSQL_PULL_SECRET
 read -e -p 'The pull secret for the icm-wa+waa image: ' -i 'dockerhub' ICM_WEB_PULL_SECRET
 set +o allexport
 

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -57,7 +57,7 @@ if [ -d "$PROJECT_ROOT/dumpfile" ]; then
     TESTDATA_BASE=$(echo "$TESTDATA_BASE" | sed "s|/run/desktop/mnt/host|/mnt|")
   fi
   mkdir -p "$TESTDATA_BASE/dumpfile"
-  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$PROJECT_ROOT"/dumpfile/*.bak "$TESTDATA_BASE/dumpfile/" 2>/dev/null || exit 1
+  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$TESTDATA_BASE/dumpfile/" 2>/dev/null || exit 1
   echo "Dumpfile copy complete."
 else
   echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -45,7 +45,21 @@ envsubst "${env_list}" < ./values-test-local.tmpl | tee values-test-local.yaml
 # create needed folders
 source ./scripts/start-test-local_dir-create.sh
 
-helm dependency update ../icm-as # wait for https://github.com/helm/helm/issues/2247
-helm dependency update ../icm
-helm dependency update .
+# Copy dumpfile directory into testdata so it's available at /data/dumpfile in the container
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+if [ -d "$PROJECT_ROOT/dumpfile" ]; then
+  echo "Copying dumpfile directory into testdata..."
+  TESTDATA_BASE=$LOCAL_MOUNT_BASE/testdata
+  VIRT_TYPE=$(systemd-detect-virt 2>/dev/null || echo "none")
+  if [ "$VIRT_TYPE" = "wsl" ]; then
+    TESTDATA_BASE=$(echo "$TESTDATA_BASE" | sed "s|/run/desktop/mnt/host|/mnt|")
+  fi
+  mkdir -p "$TESTDATA_BASE/dumpfile"
+  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$PROJECT_ROOT"/dumpfile/*.bak "$TESTDATA_BASE/dumpfile/" 2>/dev/null || exit 1
+  echo "Dumpfile copy complete."
+else
+  echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."
+fi
+
 helm upgrade --install ${HELM_DRY_RUN} ${HELM_JOB_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml

--- a/charts/icm-test/values-test-local.tmpl
+++ b/charts/icm-test/values-test-local.tmpl
@@ -14,12 +14,12 @@ icm:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-local-testdata-pvc
         mountPoint: /data
-      dumpfileRestore:
-        enabled: true
-        dumpfileDir: /data/dumpfile
-        image:
-          repository: mcr.microsoft.com/mssql-tools:latest
-        waitTimeout: 120
+    dumpfileRestore:
+      enabled: true
+      dumpfileDir: /data/dumpfile
+      image:
+        repository: mcr.microsoft.com/mssql-tools:latest
+      waitTimeout: 120
     mssql:
       enabled: true
       acceptEula: "Y"

--- a/charts/icm-test/values-test-local.tmpl
+++ b/charts/icm-test/values-test-local.tmpl
@@ -3,6 +3,7 @@ icm:
     nodeSelector: null
     imagePullSecrets:
     - "${ICM_AS_PULL_SECRET}"
+    - "${MSSQL_PULL_SECRET}"
     persistence:
       sites:
         size: 2Gi

--- a/charts/icm-test/values-test-local.tmpl
+++ b/charts/icm-test/values-test-local.tmpl
@@ -13,6 +13,12 @@ icm:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-local-testdata-pvc
         mountPoint: /data
+      dumpfileRestore:
+        enabled: true
+        dumpfileDir: /data/dumpfile
+        image:
+          repository: mcr.microsoft.com/mssql-tools:latest
+        waitTimeout: 120
     mssql:
       enabled: true
       acceptEula: "Y"


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

When the icm-test chart is used to execute a test locally, db-init has to be run which takes a long time.

Issue Number: Closes #1205

## What Is the New Behavior?

Instead we can use the corresponding database dumpfile to restore the database quickly which is now included in the Runnable Downloads of Testsuites in ISTE (see ADO: #112561). 

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information

See ADO: #112780 and #115530