### PR TITLE
feat(icm): add min ready seconds

### DIFF
--- a/charts/icm-as/templates/as-deployment.yaml
+++ b/charts/icm-as/templates/as-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- end }}
 spec:
   progressDeadlineSeconds: 600
+  minReadySeconds: {{ .Values.minReadySeconds | default 30 }}
   replicas: {{ .Values.replicaCount | default 0 }}
   revisionHistoryLimit: 10
   selector:

--- a/charts/icm-as/tests/update-strategy_test.yaml
+++ b/charts/icm-as/tests/update-strategy_test.yaml
@@ -56,3 +56,31 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
+
+  - it: delay for deployment with Recreate strategy (default)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    template: templates/as-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+
+  - it: delay for deployment with Recreate strategy (explicit)
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      minReadySeconds: 50
+    template: templates/as-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.minReadySeconds
+          value: 50

--- a/charts/icm-as/tests/update-strategy_test.yaml
+++ b/charts/icm-as/tests/update-strategy_test.yaml
@@ -57,7 +57,7 @@ tests:
           path: spec.strategy.type
           value: Recreate
 
-  - it: delay for deployment with Recreate strategy (default)
+  - it: delay for deployment (default)
     release:
       name: icm-as
     chart:
@@ -70,7 +70,7 @@ tests:
           path: spec.minReadySeconds
           value: 30
 
-  - it: delay for deployment with Recreate strategy (explicit)
+  - it: delay for deployment (explicit)
     release:
       name: icm-as
     chart:

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 
 # define the update strategy (possible values: Recreate, RollingUpdate; default=RollingUpdate)
 updateStrategy: RollingUpdate
+# minReadySeconds: 30
 
 # define where the application shall run on
 nodeSelector: {}
@@ -367,9 +368,9 @@ probes:
   #    initialDelaySeconds: 0
   #    periodSeconds: 10
   readiness: {}
-#    failureThreshold: 3
-#    initialDelaySeconds: 0
-#    periodSeconds: 5
+  #    failureThreshold: 3
+  #    initialDelaySeconds: 60
+  #    periodSeconds: 10
 
 # Duration in seconds pod needs to terminate gracefully, value is optional, below is the default
 # terminationGracePeriodSeconds: 30


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

During deployment of a new application server instance, the CPU naturally increases because the caches are not filled.
The deployment starts rolling the next instance without give the new instance time to build up caches.

Issue Number: Closes #1220 

## What Is the New Behavior?

The new configuration option "minReadySeconds" creates a pause (default 30s) between appserver instance deployments.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other Information

The default is requested by operations. The developers can change that value via values.yaml.
Related ticket is 114901.
