### PR TITLE
feat(icm): enable automatic database dumpfile import using a kubernetes job

### DIFF
--- a/charts/icm-test/docs/local-execution.asciidoc
+++ b/charts/icm-test/docs/local-execution.asciidoc
@@ -12,7 +12,7 @@ This document describes how to run the ICM Test Chart locally using Docker Deskt
 
 === 1. Switch kubectl context to local Docker
 
-Start Docker Desktop and ensure it is running with Kubernetes. Then, switch your kubectl context to Docker Desktop using the following command.
+Start Docker Desktop and ensure it is running with Kubernetes. It is recommended to use kubeadm as the cluster type. Then, switch your kubectl context to Docker Desktop using the following command.
 
 [source,bash]
 ----
@@ -88,8 +88,9 @@ You can now run the `start-test-local.sh` script using `./start-test-local.sh`. 
 . Helm Chart Name: The name of the helm chart as you want to release it. This MUST match the name you set earlier in the hosts file (Step 6).
 . Testsuite: The name of the testsuite you want to run.
 . Test image: The image you want to run your test on. You can either use the default or specify your own. You can get possible images from the ISTE or from Dockerhub. In ISTE: Open the files of a testplan and look for a file called `helm_install_vars.sh`. In there you will find a field called `ICM_TEST_IMAGE`. This is the image name you need to use here.
-. Base path of your local folder mount: This is the path to the persistent volume directories you created earlier.
+. Base path of your local folder mount: This is the path to the persistent volume directories you created earlier. Note: Due to the way local folders are mounted into the docker desktop kubernetes cluster, the path needs to be in the format `/run/desktop/mnt/host/<your_path>`.
 . The pull secret for the icm-as+testrunner image: This is the pull secret from where you want to pull the test image. With default naming conventions this should be `dockerhub`. If you want to pull your image from the azure container registry, this secret needs to be `icmbuildsnapshot`.
+. The pull secret for the MSSQL image: This is the pull secret used to pull the MSSQL database image. With default naming conventions this should be `dockerhub`.
 . The pull secret for the icm-wa+waa image: This is the pull secret for Docker Hub. With default naming conventions this should be `dockerhub`.
 
 The script will also verify if you have correctly configured the kubernetes secrets.

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -63,4 +63,14 @@ else
   echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."
 fi
 
+# Update dependencies from source charts if they exist
+# When running standalone with pre-bundled charts/ this is skipped (happens in local execution)
+if [ -d "../icm-as" ]; then
+  helm dependency update ../icm-as # wait for https://github.com/helm/helm/issues/2247
+fi
+if [ -d "../icm" ]; then
+  helm dependency update ../icm
+fi
+helm dependency update .
+
 helm upgrade --install ${HELM_DRY_RUN} ${HELM_JOB_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -63,14 +63,12 @@ else
   echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."
 fi
 
-# Update dependencies from source charts if they exist
-# When running standalone with pre-bundled charts/ this is skipped (happens in local execution)
-if [ -d "../icm-as" ]; then
+# Update dependencies from source charts if sibling chart directories exist (i.e. running from the full repo).
+# When running standalone with pre-bundled charts/ this is skipped.
+if [ -d "../icm-as" ] && [ -d "../icm" ]; then
   helm dependency update ../icm-as # wait for https://github.com/helm/helm/issues/2247
-fi
-if [ -d "../icm" ]; then
   helm dependency update ../icm
+  helm dependency update .
 fi
-helm dependency update .
 
 helm upgrade --install ${HELM_DRY_RUN} ${HELM_JOB_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -57,7 +57,7 @@ if [ -d "$PROJECT_ROOT/dumpfile" ]; then
     TESTDATA_BASE=$(echo "$TESTDATA_BASE" | sed "s|/run/desktop/mnt/host|/mnt|")
   fi
   mkdir -p "$TESTDATA_BASE/dumpfile"
-  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$TESTDATA_BASE/dumpfile/" 2>/dev/null || exit 1
+  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$TESTDATA_BASE/dumpfile/" 2>/dev/null || echo "No .dmp files found in $PROJECT_ROOT/dumpfile, skipping."
   echo "Dumpfile copy complete."
 else
   echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."

--- a/charts/icm-test/start-test-local.sh
+++ b/charts/icm-test/start-test-local.sh
@@ -31,6 +31,7 @@ fi
 
 read -e -p 'Base path of your local folder mount: ' -i '/run/desktop/mnt/host/d/tmp/pv' LOCAL_MOUNT_BASE
 read -e -p 'The pull secret for the icm-as+testrunner image (e.g. dockerhub or icmbuildsnapshot): ' -i 'dockerhub' ICM_AS_PULL_SECRET
+read -e -p 'The pull secret for the mssql image (e.g dockerhub): ' -i 'dockerhub' MSSQL_PULL_SECRET
 read -e -p 'The pull secret for the icm-wa+waa image: ' -i 'dockerhub' ICM_WEB_PULL_SECRET
 set +o allexport
 
@@ -45,7 +46,21 @@ envsubst "${env_list}" < ./values-test-local.tmpl | tee values-test-local.yaml
 # create needed folders
 source ./scripts/start-test-local_dir-create.sh
 
-helm dependency update ../icm-as # wait for https://github.com/helm/helm/issues/2247
-helm dependency update ../icm
-helm dependency update .
+# Copy dumpfile directory into testdata so it's available at /data/dumpfile in the container
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+if [ -d "$PROJECT_ROOT/dumpfile" ]; then
+  echo "Copying dumpfile directory into testdata..."
+  TESTDATA_BASE=$LOCAL_MOUNT_BASE/testdata
+  VIRT_TYPE=$(systemd-detect-virt 2>/dev/null || echo "none")
+  if [ "$VIRT_TYPE" = "wsl" ]; then
+    TESTDATA_BASE=$(echo "$TESTDATA_BASE" | sed "s|/run/desktop/mnt/host|/mnt|")
+  fi
+  mkdir -p "$TESTDATA_BASE/dumpfile"
+  cp -v "$PROJECT_ROOT"/dumpfile/*.dmp "$TESTDATA_BASE/dumpfile/" 2>/dev/null || exit 1
+  echo "Dumpfile copy complete."
+else
+  echo "No dumpfile directory found at $PROJECT_ROOT/dumpfile, skipping copy."
+fi
+
 helm upgrade --install ${HELM_DRY_RUN} ${HELM_JOB_NAME} . -f ./values-iste_linux.yaml -f ./values-test-local.yaml

--- a/charts/icm-test/templates/_helpers.tpl
+++ b/charts/icm-test/templates/_helpers.tpl
@@ -37,6 +37,68 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create the fullname of the nested icm-as release.
+*/}}
+{{- define "icm-test.icmAsFullname" -}}
+{{- $icmAsValues := index .Values.icm "icm-as" -}}
+{{- if $icmAsValues.fullnameOverride -}}
+{{- $icmAsValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "icm-as" $icmAsValues.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the MSSQL service name of the nested icm-as release.
+*/}}
+{{- define "icm-test.icmAsMssqlServiceName" -}}
+{{- printf "%s-mssql-service" (include "icm-test.icmAsFullname" .) -}}
+{{- end -}}
+
+{{/*
+Create the MSSQL backup claim name of the nested icm-as release.
+*/}}
+{{- define "icm-test.icmAsMssqlBackupClaimName" -}}
+{{- $icmAsValues := index .Values.icm "icm-as" -}}
+{{- if eq $icmAsValues.mssql.persistence.backup.type "local" -}}
+{{- printf "%s-local-mssql-db-backup-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else if eq $icmAsValues.mssql.persistence.backup.type "existingClaim" -}}
+{{- $icmAsValues.mssql.persistence.backup.existingClaim -}}
+{{- else if eq $icmAsValues.mssql.persistence.backup.type "nfs" -}}
+{{- printf "%s-nfs-mssql-db-backup-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else if eq $icmAsValues.mssql.persistence.backup.type "cluster" -}}
+{{- printf "%s-cluster-mssql-db-backup-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the sites PVC claim name of the nested icm-as release.
+*/}}
+{{- define "icm-test.icmAsSitesClaimName" -}}
+{{- $icmAsValues := index .Values.icm "icm-as" -}}
+{{- if eq $icmAsValues.persistence.sites.type "local" -}}
+{{- printf "%s-local-sites-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else if eq $icmAsValues.persistence.sites.type "existingClaim" -}}
+{{- $icmAsValues.persistence.sites.existingClaim -}}
+{{- else if eq $icmAsValues.persistence.sites.type "nfs" -}}
+{{- printf "%s-nfs-sites-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else if eq $icmAsValues.persistence.sites.type "cluster" -}}
+{{- printf "%s-cluster-sites-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- else if eq $icmAsValues.persistence.sites.type "azurefiles" -}}
+{{- "" -}}
+{{- else -}}
+{{- printf "%s-static-sites-pvc" (include "icm-test.icmAsFullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "icm-test.chart" -}}

--- a/charts/icm-test/templates/db-restore-job.yaml
+++ b/charts/icm-test/templates/db-restore-job.yaml
@@ -1,0 +1,159 @@
+{{- $icmAsValues := index .Values.icm "icm-as" -}}
+{{- if and .Values.test.enabled $icmAsValues.mssql.enabled .Values.dumpfileRestore.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "icm-test.fullname" . }}-db-restore
+  labels:
+    helm.sh/chart: {{ include "icm-test.chart" . }}
+    app.kubernetes.io/name: {{ template "icm-test.fullname" . }}-db-restore
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "icm-test.fullname" . }}-db-restore
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if $icmAsValues.nodeSelector }}
+      nodeSelector:
+        {{- toYaml $icmAsValues.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if $icmAsValues.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range $icmAsValues.imagePullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      restartPolicy: Never
+      {{- if $icmAsValues.copySitesDir.enabled }}
+      initContainers:
+      - name: cp-sites-dir
+        image: "{{ $icmAsValues.image.repository }}{{ if not (contains ":" $icmAsValues.image.repository) }}:{{ $icmAsValues.image.tag | default $.Chart.AppVersion }}{{ end }}"
+        command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          set -x
+          SITES_DIR={{ $icmAsValues.copySitesDir.fromDir }}
+          if [ -d "$SITES_DIR" ]; then
+            SITES_VOL=/intershop
+            cp -r $SITES_DIR $SITES_VOL
+            chmod 777 $SITES_VOL/sites && chown -R {{ $icmAsValues.copySitesDir.chmodUser }}:{{ $icmAsValues.copySitesDir.chmodGroup }} $SITES_VOL/sites
+            find $SITES_VOL -type f > "{{ $icmAsValues.copySitesDir.resultDir }}/sites.txt"
+          fi
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+        - name: sites-volume
+          mountPath: /intershop/sites
+        {{- if $icmAsValues.persistence.customdata.enabled }}
+        - name: custom-data-volume
+          mountPath: {{ $icmAsValues.persistence.customdata.mountPoint | default "/data" }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: db-restore-from-dumpfile
+        image: "{{ .Values.dumpfileRestore.image.repository }}"
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          set -e
+          DUMPFILE_DIR="{{ .Values.dumpfileRestore.dumpfileDir }}"
+          if [ ! -d "$DUMPFILE_DIR" ]; then
+            echo "Dumpfile directory $DUMPFILE_DIR does not exist, skipping restore."
+            exit 0
+          fi
+          DUMPFILE=$(find "$DUMPFILE_DIR" -maxdepth 1 \( -name "*.dmp" -o -name "*.bak" \) 2>/dev/null | head -1)
+          if [ -z "$DUMPFILE" ]; then
+            echo "No dumpfile found in $DUMPFILE_DIR, skipping restore."
+            exit 0
+          fi
+          echo "Found dumpfile: $DUMPFILE"
+          FILENAME=$(basename "$DUMPFILE")
+          echo "Copying dumpfile to MSSQL backup volume..."
+          cp "$DUMPFILE" /mssql-backup/
+          echo "Dumpfile copied successfully."
+          MSSQL_HOST="{{ include "icm-test.icmAsMssqlServiceName" . }}"
+          SA_PASSWORD="{{ $icmAsValues.mssql.saPassword }}"
+          DB_NAME="{{ $icmAsValues.mssql.databaseName }}"
+          echo "Waiting for MSSQL at $MSSQL_HOST to be ready..."
+          for i in $(seq 1 {{ .Values.dumpfileRestore.waitTimeout }}); do
+            if /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "SELECT 1" > /dev/null 2>&1; then
+              echo "MSSQL is ready after ${i}s."
+              break
+            fi
+            if [ "$i" -eq {{ .Values.dumpfileRestore.waitTimeout }} ]; then
+              echo "ERROR: MSSQL did not become ready within {{ .Values.dumpfileRestore.waitTimeout }}s."
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Restoring database '$DB_NAME' from /var/opt/mssql/backup/$FILENAME..."
+          /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "RESTORE DATABASE [$DB_NAME] FROM DISK = N'/var/opt/mssql/backup/$FILENAME' WITH REPLACE"
+          if [ $? -eq 0 ]; then
+            echo "Database restore completed successfully."
+            DB_USER="{{ $icmAsValues.mssql.user }}"
+            DB_PASSWORD="{{ $icmAsValues.mssql.password }}"
+            echo "Fixing database user mapping for $DB_USER..."
+            /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "USE [$DB_NAME]; IF NOT EXISTS (SELECT name FROM master.sys.server_principals WHERE name = '$DB_USER') BEGIN CREATE LOGIN [$DB_USER] WITH PASSWORD = '$DB_PASSWORD', CHECK_POLICY = OFF END; IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = '$DB_USER') BEGIN CREATE USER [$DB_USER] FOR LOGIN [$DB_USER] END ELSE BEGIN ALTER USER [$DB_USER] WITH LOGIN = [$DB_USER] END; ALTER ROLE [db_owner] ADD MEMBER [$DB_USER];"
+          else
+            echo "ERROR: Database restore failed."
+            exit 1
+          fi
+        volumeMounts:
+        {{- if $icmAsValues.persistence.customdata.enabled }}
+        - name: custom-data-volume
+          mountPath: {{ $icmAsValues.persistence.customdata.mountPoint | default "/data" }}
+        {{- end }}
+        - name: mssql-backup-volume
+          mountPath: /mssql-backup
+        securityContext:
+          runAsUser: 0
+      volumes:
+      {{- if $icmAsValues.copySitesDir.enabled }}
+      - name: sites-volume
+        {{- if eq $icmAsValues.persistence.sites.type "azurefiles" }}
+        csi:
+          driver: file.csi.azure.com
+          readOnly: false
+          volumeAttributes:
+            secretName: {{ $icmAsValues.persistence.sites.azurefiles.secretName }}
+            shareName: {{ $icmAsValues.persistence.sites.azurefiles.shareName }}
+        {{- else }}
+        persistentVolumeClaim:
+          claimName: "{{ include "icm-test.icmAsSitesClaimName" . }}"
+        {{- end }}
+      {{- end }}
+      {{- if $icmAsValues.persistence.customdata.enabled }}
+      - name: custom-data-volume
+        persistentVolumeClaim:
+          claimName: "{{ $icmAsValues.persistence.customdata.existingClaim }}"
+      {{- end }}
+      - name: mssql-backup-volume
+        {{- if eq $icmAsValues.mssql.persistence.backup.type "local" }}
+        persistentVolumeClaim:
+          claimName: "{{ include "icm-test.icmAsMssqlBackupClaimName" . }}"
+        {{- else if eq $icmAsValues.mssql.persistence.backup.type "existingClaim" }}
+        persistentVolumeClaim:
+          claimName: "{{ include "icm-test.icmAsMssqlBackupClaimName" . }}"
+        {{- else if eq $icmAsValues.mssql.persistence.backup.type "azurefiles" }}
+        azureFile:
+          secretName: {{ $icmAsValues.mssql.persistence.backup.azurefiles.secretName }}
+          shareName: {{ $icmAsValues.mssql.persistence.backup.azurefiles.shareName }}
+          readOnly: false
+        {{- else if eq $icmAsValues.mssql.persistence.backup.type "nfs" }}
+        persistentVolumeClaim:
+          claimName: "{{ include "icm-test.icmAsMssqlBackupClaimName" . }}"
+        {{- else if eq $icmAsValues.mssql.persistence.backup.type "cluster" }}
+        persistentVolumeClaim:
+          claimName: "{{ include "icm-test.icmAsMssqlBackupClaimName" . }}"
+        {{- else }}
+        {{- fail (printf "Unsupported mssql.persistence.backup.type: %s (supported: local, existingClaim, azurefiles, nfs, cluster)" $icmAsValues.mssql.persistence.backup.type) }}
+        {{- end }}
+{{- end }}

--- a/charts/icm-test/templates/db-restore-job.yaml
+++ b/charts/icm-test/templates/db-restore-job.yaml
@@ -95,8 +95,7 @@ spec:
             sleep 1
           done
           echo "Restoring database '$DB_NAME' from /var/opt/mssql/backup/$FILENAME..."
-          /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "RESTORE DATABASE [$DB_NAME] FROM DISK = N'/var/opt/mssql/backup/$FILENAME' WITH REPLACE"
-          if [ $? -eq 0 ]; then
+          if /opt/mssql-tools/bin/sqlcmd -S "$MSSQL_HOST" -U sa -P "$SA_PASSWORD" -Q "RESTORE DATABASE [$DB_NAME] FROM DISK = N'/var/opt/mssql/backup/$FILENAME' WITH REPLACE"; then
             echo "Database restore completed successfully."
             DB_USER="{{ $icmAsValues.mssql.user }}"
             DB_PASSWORD="{{ $icmAsValues.mssql.password }}"

--- a/charts/icm-test/templates/db-restore-job.yaml
+++ b/charts/icm-test/templates/db-restore-job.yaml
@@ -37,11 +37,11 @@ spec:
         - |
           set -x
           SITES_DIR={{ $icmAsValues.copySitesDir.fromDir }}
+          SITES_VOL=/mnt/sites
           if [ -d "$SITES_DIR" ]; then
-            SITES_VOL=/intershop
-            cp -r $SITES_DIR $SITES_VOL
-            chmod 777 $SITES_VOL/sites && chown -R {{ $icmAsValues.copySitesDir.chmodUser }}:{{ $icmAsValues.copySitesDir.chmodGroup }} $SITES_VOL/sites
-            find $SITES_VOL -type f > "{{ $icmAsValues.copySitesDir.resultDir }}/sites.txt"
+            cp -r "$SITES_DIR"/* "$SITES_VOL"/
+            chmod 777 "$SITES_VOL" && chown -R {{ $icmAsValues.copySitesDir.chmodUser }}:{{ $icmAsValues.copySitesDir.chmodGroup }} "$SITES_VOL"
+            find "$SITES_VOL" -type f > "{{ $icmAsValues.copySitesDir.resultDir }}/sites.txt"
           fi
         imagePullPolicy: IfNotPresent
         securityContext:
@@ -49,7 +49,7 @@ spec:
           runAsGroup: 0
         volumeMounts:
         - name: sites-volume
-          mountPath: /intershop/sites
+          mountPath: /mnt/sites
         {{- if $icmAsValues.persistence.customdata.enabled }}
         - name: custom-data-volume
           mountPath: {{ $icmAsValues.persistence.customdata.mountPoint | default "/data" }}

--- a/charts/icm-test/templates/db-restore-job.yaml
+++ b/charts/icm-test/templates/db-restore-job.yaml
@@ -119,12 +119,10 @@ spec:
       {{- if $icmAsValues.copySitesDir.enabled }}
       - name: sites-volume
         {{- if eq $icmAsValues.persistence.sites.type "azurefiles" }}
-        csi:
-          driver: file.csi.azure.com
+        azureFile:
+          secretName: {{ $icmAsValues.persistence.sites.azurefiles.secretName }}
+          shareName: {{ $icmAsValues.persistence.sites.azurefiles.shareName }}
           readOnly: false
-          volumeAttributes:
-            secretName: {{ $icmAsValues.persistence.sites.azurefiles.secretName }}
-            shareName: {{ $icmAsValues.persistence.sites.azurefiles.shareName }}
         {{- else }}
         persistentVolumeClaim:
           claimName: "{{ include "icm-test.icmAsSitesClaimName" . }}"

--- a/charts/icm-test/templates/db-restore-job.yaml
+++ b/charts/icm-test/templates/db-restore-job.yaml
@@ -69,9 +69,9 @@ spec:
             echo "Dumpfile directory $DUMPFILE_DIR does not exist, skipping restore."
             exit 0
           fi
-          DUMPFILE=$(find "$DUMPFILE_DIR" -maxdepth 1 \( -name "*.dmp" -o -name "*.bak" \) 2>/dev/null | head -1)
+          DUMPFILE=$(find "$DUMPFILE_DIR" -maxdepth 1 -name "*.dmp" 2>/dev/null | head -1)
           if [ -z "$DUMPFILE" ]; then
-            echo "No dumpfile found in $DUMPFILE_DIR, skipping restore."
+            echo "No .dmp file found in $DUMPFILE_DIR, skipping restore."
             exit 0
           fi
           echo "Found dumpfile: $DUMPFILE"

--- a/charts/icm-test/tests/dumpfile-restore-job_test.yaml
+++ b/charts/icm-test/tests/dumpfile-restore-job_test.yaml
@@ -1,0 +1,97 @@
+suite: tests dumpfileRestore job
+templates:
+  - templates/db-restore-job.yaml
+tests:
+  - it: db-restore job is absent by default
+    release:
+      name: icm
+    chart:
+      version: 0.8.15
+    values:
+      - ../values-iste_linux.tmpl
+    template: templates/db-restore-job.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: db-restore job renders with local backup pvc
+    release:
+      name: icm
+    chart:
+      version: 0.8.15
+    values:
+      - ../values-iste_linux.tmpl
+      - ../values-test-local.tmpl
+    template: templates/db-restore-job.yaml
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: icm-icm-test-db-restore
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: db-restore-from-dumpfile
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: mcr.microsoft.com/mssql-tools:latest
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-data-volume
+            persistentVolumeClaim:
+              claimName: "${HELM_JOB_NAME}-local-testdata-pvc"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            persistentVolumeClaim:
+              claimName: "icm-icm-as-local-mssql-db-backup-pvc"
+
+  - it: db-restore job renders azurefiles backup volume
+    release:
+      name: icm
+    chart:
+      version: 0.8.15
+    values:
+      - ../values-iste_linux.tmpl
+    set:
+      icm.icm-as.mssql.enabled: true
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /data/dumpfile
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+      icm.icm-as.persistence.customdata.enabled: true
+      icm.icm-as.persistence.customdata.existingClaim: custom-data-claim
+      icm.icm-as.mssql.persistence.backup.type: azurefiles
+      icm.icm-as.mssql.persistence.backup.azurefiles.secretName: backup-secret
+      icm.icm-as.mssql.persistence.backup.azurefiles.shareName: backup-share
+    template: templates/db-restore-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mssql-backup-volume
+            azureFile:
+              secretName: backup-secret
+              shareName: backup-share
+              readOnly: false
+
+  - it: fails on unknown mssql.persistence.backup.type
+    release:
+      name: icm
+    chart:
+      version: 0.8.15
+    values:
+      - ../values-iste_linux.tmpl
+    set:
+      icm.icm-as.mssql.enabled: true
+      dumpfileRestore.enabled: true
+      dumpfileRestore.dumpfileDir: /data/dumpfile
+      dumpfileRestore.image.repository: mcr.microsoft.com/mssql-tools
+      dumpfileRestore.waitTimeout: 60
+      icm.icm-as.mssql.persistence.backup.type: bogus
+    template: templates/db-restore-job.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Unsupported mssql.persistence.backup.type: bogus (supported: local, existingClaim, azurefiles, nfs, cluster)"

--- a/charts/icm-test/values-test-local.tmpl
+++ b/charts/icm-test/values-test-local.tmpl
@@ -13,6 +13,12 @@ icm:
         enabled: true
         existingClaim: ${HELM_JOB_NAME}-local-testdata-pvc
         mountPoint: /data
+    copySitesDir:
+      enabled: true
+      fromDir: /intershop/sites
+      resultDir: /data
+      chmodUser: 150
+      chmodGroup: 150
     mssql:
       enabled: true
       acceptEula: "Y"
@@ -52,3 +58,10 @@ testrunner:
       type: local
       local:
         dir: ${LOCAL_MOUNT_BASE}/testdata
+
+dumpfileRestore:
+  enabled: true
+  dumpfileDir: /data/dumpfile
+  image:
+    repository: mcr.microsoft.com/mssql-tools:latest
+  waitTimeout: 120

--- a/charts/icm-test/values-test-local.tmpl
+++ b/charts/icm-test/values-test-local.tmpl
@@ -3,6 +3,7 @@ icm:
     nodeSelector: null
     imagePullSecrets:
     - "${ICM_AS_PULL_SECRET}"
+    - "${MSSQL_PULL_SECRET}"
     persistence:
       sites:
         size: 2Gi

--- a/charts/icm-test/values.yaml
+++ b/charts/icm-test/values.yaml
@@ -7,3 +7,13 @@ test:
         type: local
         local:
           dir: /invaliddir
+
+# Restore database from a dump file found in a dumpfile directory
+dumpfileRestore:
+  enabled: false
+  # Path to directory containing the .dmp or .bak file
+  dumpfileDir: /data/dumpfile
+  image:
+    repository: mcr.microsoft.com/mssql-tools:latest
+  # Max seconds to wait for MSSQL to become ready
+  waitTimeout: 120


### PR DESCRIPTION
<!--
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/intershop/helm-charts/blob/develop/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Be sure to include PR label `major`, `minor` or `patch` when merging into `main`
-->

## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

When running a testsuite locally, it first needs to run db-init to initialise the database. This can take a long time (between 30-60 minutes). 

Issue Number: Closes #1205 

## What Is the New Behavior?

You can now use a dumpfile to automatically restore the database from it and skip the db-init step. This takes the time it takes to start the testrunner pod down to less than 5 minutes.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

