### PR TITLE
Feature#1219 integrate wamonitoringexporter into wa pods

### DIFF
--- a/charts/icm-web/docs/values-yaml.asciidoc
+++ b/charts/icm-web/docs/values-yaml.asciidoc
@@ -31,5 +31,6 @@ The following table gives a short overview about the different sections (sorted 
 |link:values-yaml/pod-security-context.asciidoc[podSecurityContext]|Pod security context
 |link:values-yaml/resources.asciidoc[resources]|Configures the resource definitions (requests, limits) for the icm-as-server and the jobserver containers
 |link:values-yaml/service.asciidoc[service]|Service configuration
+|link:values-yaml/wa-monitoring.asciidoc[waMonitoring]|Web Adapter monitoring sidecar configuration
 |link:values-yaml/webadapter.asciidoc[webadapter]|Web Adapter (`icm-web-wa`) configuration
 |===

--- a/charts/icm-web/docs/values-yaml/wa-monitoring.asciidoc
+++ b/charts/icm-web/docs/values-yaml/wa-monitoring.asciidoc
@@ -1,0 +1,39 @@
+= `values.yaml` Attributes in Section `waMonitoring`
+
+:icons: font
+
+:mandatory: image:../images/mandatory.webp[]
+:optional: image:../images/optional.webp[]
+:conditional: image:../images/conditional.webp[]
+
+
+== Description
+
+Configures the monitoring sidecar (exposed Prometheus metrics gathered from webadapter) for the webadapter.
+
+The `waMonitoring` section contains an attribute that is described in the `icm-as` Helm Chart documentation:
+
+* link:../../../icm-as/docs/values-yaml/image.asciidoc[image]
+
+The following table lists attributes that are specific to the `waMonitoring` section:
+
+[cols="1,3,1,1,1",options="header"]
+|===
+|Attribute |Description |Type |Mandatory |Default Value
+|enabled|Enable/disable the monitoring sidecar|boolean|{optional}|`true`
+|appServerUnavailableTimeout|How long to keep waStatistics related metrics available while the related app server is unavailable (syntax compatible with Go duration)|string|{optional}|`30s`
+|scraptingInterval|Interval between scraping (metrics update) requests (syntax compatible with Go duration)|string|{optional}|`5s`
+|===
+
+== Example
+
+[source,yaml]
+----
+waMonitoring:
+  enabled: true
+  image:
+    repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+    pullPolicy: "IfNotPresent"
+  appServerUnavailableTimeout: 30s
+  scraptingInterval: 5s
+----

--- a/charts/icm-web/docs/values-yaml/wa-monitoring.asciidoc
+++ b/charts/icm-web/docs/values-yaml/wa-monitoring.asciidoc
@@ -22,7 +22,7 @@ The following table lists attributes that are specific to the `waMonitoring` sec
 |Attribute |Description |Type |Mandatory |Default Value
 |enabled|Enable/disable the monitoring sidecar|boolean|{optional}|`true`
 |appServerUnavailableTimeout|How long to keep waStatistics related metrics available while the related app server is unavailable (syntax compatible with Go duration)|string|{optional}|`30s`
-|scraptingInterval|Interval between scraping (metrics update) requests (syntax compatible with Go duration)|string|{optional}|`5s`
+|scrapingInterval|Interval between scraping (metrics update) requests (syntax compatible with Go duration)|string|{optional}|`5s`
 |===
 
 == Example
@@ -32,8 +32,8 @@ The following table lists attributes that are specific to the `waMonitoring` sec
 waMonitoring:
   enabled: true
   image:
-    repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+    repository: "intershophub/icm-wa-monitoring-exporter:1.1.0"
     pullPolicy: "IfNotPresent"
   appServerUnavailableTimeout: 30s
-  scraptingInterval: 5s
+  scrapingInterval: 5s
 ----

--- a/charts/icm-web/templates/_helpers.tpl
+++ b/charts/icm-web/templates/_helpers.tpl
@@ -81,5 +81,5 @@ Create the name of the service account to use
 Create the name of the service
 */}}
 {{- define "icm-web.waServiceName" -}}
-{{- include "icm-web.fullname" . -}}-wa
+{{- printf "%s-wa" (include "icm-web.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/icm-web/templates/_helpers.tpl
+++ b/charts/icm-web/templates/_helpers.tpl
@@ -76,3 +76,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service
+*/}}
+{{- define "icm-web.waServiceName" -}}
+{{- include "icm-web.fullname" . -}}-wa
+{{- end -}}

--- a/charts/icm-web/templates/_operationalContext.tpl
+++ b/charts/icm-web/templates/_operationalContext.tpl
@@ -25,12 +25,17 @@ Renders values from the operational context
   {{- .Values.operationalContext.stagingType | default "standalone" -}}
 {{- end -}}
 
+{{- define "icm-web.customerId" -}}
+  {{- include "icm-web.operationalContext" . -}}
+  {{- .Values.operationalContext.customerId | default "n_a" -}}
+{{- end -}}
+
 {{/*
 Renders the operational context name
 */}}
 {{- define "icm-web.operationalContextName" -}}
   {{- include "icm-web.operationalContext" . -}}
-  {{- $customerId := .Values.operationalContext.customerId | default "n_a" -}}
+  {{- $customerId := include "icm-web.customerId" . -}}
   {{- $environmentName := include "icm-web.environmentName" . -}}
   {{- $stagingType := include "icm-web.stagingType" . -}}
   {{- printf "%s-%s-%s" $customerId $environmentName $stagingType -}}

--- a/charts/icm-web/templates/_waMonitoringExporter.tpl
+++ b/charts/icm-web/templates/_waMonitoringExporter.tpl
@@ -1,12 +1,15 @@
 {{/* vim: set filetype=mustache: */}}
 {{- define "icm-wa.monitoringContainer" -}}
 {{- $waMon := default dict .Values.waMonitoring }}
+{{- $waMonImage := dig "image" dict $waMon }}
+{{- $waMonImageRepository := dig "repository" "" $waMonImage }}
+{{- $waMonImageTag := dig "tag" "" $waMonImage }}
 {{- if dig "enabled" true $waMon }}
 - name: "{{ .Chart.Name }}-wa-monitoring"
-  {{- if not (dig "image" "repository" "" $waMon) }}
+  {{- if not $waMonImageRepository }}
     {{- fail "Error: missing value at waMonitoring.image.repository." -}}
   {{- end }}
-  image: {{ $waMon.image.repository | quote }}
+  image: {{- if $waMonImageTag }} {{ printf "%s:%s" $waMonImageRepository $waMonImageTag | quote }}{{- else }} {{ $waMonImageRepository | quote }}{{- end }}
   imagePullPolicy: {{ (dig "image" "pullPolicy" "IfNotPresent" $waMon) | quote }}
   env:
   - name: WA_CONFIG

--- a/charts/icm-web/templates/_waMonitoringExporter.tpl
+++ b/charts/icm-web/templates/_waMonitoringExporter.tpl
@@ -15,9 +15,9 @@
   - name: WA_CONFIG
     value: "env"
   - name: WA_TENANT
-    value: {{ include "icm-web.customerId" . }}
+    value: {{ include "icm-web.customerId" . | quote }}
   - name: WA_ENVIRONMENT
-    value: {{ printf "%s-%s" (include "icm-web.environmentType" .) (include "icm-web.stagingType" .) }}
+    value: {{ printf "%s-%s" (include "icm-web.environmentType" .) (include "icm-web.stagingType" .) | quote }}
   - name: WA_SKIP_CERT_VALIDATION
     value: "true"
   - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT

--- a/charts/icm-web/templates/_waMonitoringExporter.tpl
+++ b/charts/icm-web/templates/_waMonitoringExporter.tpl
@@ -22,11 +22,11 @@
   - name: WA_LOG
     value: "/intershop/logs"
   - name: WA_URI
-    value: {{ printf "http://%s:8080/INTERSHOP/wastatistics" (include "icm-web.waServiceName" .) | quote }}
+    value: "http://localhost:8080/INTERSHOP/wastatistics"
   - name: HTTPD_STATUS_URI
-    value: {{ printf "http://%s:8080/server-status?auto" (include "icm-web.waServiceName" .) | quote }}
+    value: "http://localhost:8080/server-status?auto"
   - name: SCRAPE_INTERVAL
-    value: {{ (dig "scraptingInterval" "5s" $waMon) | quote }}
+    value: {{ (dig "scrapingInterval" "5s" $waMon) | quote }}
   ports:
   - name: metrics
     containerPort: 2112

--- a/charts/icm-web/templates/_waMonitoringExporter.tpl
+++ b/charts/icm-web/templates/_waMonitoringExporter.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{- define "icm-wa.monitoringContainer" -}}
+{{- $waMon := default dict .Values.waMonitoring }}
+{{- if dig "enabled" true $waMon }}
+- name: "{{ .Chart.Name }}-wa-monitoring"
+  {{- if not (dig "image" "repository" "" $waMon) }}
+    {{- fail "Error: missing value at waMonitoring.image.repository." -}}
+  {{- end }}
+  image: {{ $waMon.image.repository | quote }}
+  imagePullPolicy: {{ (dig "image" "pullPolicy" "IfNotPresent" $waMon) | quote }}
+  env:
+  - name: WA_CONFIG
+    value: "env"
+  - name: WA_TENANT
+    value: {{ include "icm-web.customerId" . }}
+  - name: WA_ENVIRONMENT
+    value: {{ printf "%s-%s" (include "icm-web.environmentType" .) (include "icm-web.stagingType" .) }}
+  - name: WA_SKIP_CERT_VALIDATION
+    value: "true"
+  - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+    value: {{ (dig "appServerUnavailableTimeout" "30s" $waMon) | quote }}
+  - name: WA_LOG
+    value: "/intershop/logs"
+  - name: WA_URI
+    value: {{ printf "http://%s:8080/INTERSHOP/wastatistics" (include "icm-web.waServiceName" .) | quote }}
+  - name: HTTPD_STATUS_URI
+    value: {{ printf "http://%s:8080/server-status?auto" (include "icm-web.waServiceName" .) | quote }}
+  - name: SCRAPE_INTERVAL
+    value: {{ (dig "scraptingInterval" "5s" $waMon) | quote }}
+  ports:
+  - name: metrics
+    containerPort: 2112
+    protocol: TCP
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  volumeMounts:
+    - name: "logs-volume"
+      mountPath: "/intershop/logs"
+{{- end }}
+{{- end -}}

--- a/charts/icm-web/templates/_waaContainer.tpl
+++ b/charts/icm-web/templates/_waaContainer.tpl
@@ -51,5 +51,5 @@ volumeMounts:
   mountPath: {{ .Values.persistence.customdata.mountPoint }}
 {{- end }}
 resources:
-  {{- toYaml .Values.resources.agent | nindent 12 }}
+  {{ toYaml .Values.resources.agent | nindent 2 }}
 {{- end -}}

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -248,4 +248,5 @@ spec:
         {{- if (and .Values.agent.enabled (eq .Values.persistence.pagecache.type "emptyDir"))}}
         - name: "{{ .Chart.Name }}-agent"
           {{- include "icm-waa.container" . | nindent 10 }}
-        {{- end }}
+        {{- end -}}
+        {{- include "icm-wa.monitoringContainer" . | nindent 8 }}

--- a/charts/icm-web/templates/wa-monitoring-service.yaml
+++ b/charts/icm-web/templates/wa-monitoring-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-wa-monitoring" (include "icm-web.fullname" .) | lower }}
+  name: {{ printf "%s-wa-monitoring" (include "icm-web.fullname" .) | lower | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "icm-web.labels" $ctx | nindent 4 }}
   annotations:
@@ -19,6 +19,4 @@ spec:
     protocol: TCP
   selector:
     {{- include "icm-web.selectorLabels" $ctx | nindent 4 }}
-status:
-  loadBalancer: {}
 {{- end }}

--- a/charts/icm-web/templates/wa-monitoring-service.yaml
+++ b/charts/icm-web/templates/wa-monitoring-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.waMonitoring.enabled }}
+{{- $ctx := dict "root" . "component" "webadapter" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-wa-monitoring" (include "icm-web.fullname" .) | lower }}
+  labels:
+    {{- include "icm-web.labels" $ctx | nindent 4 }}
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '2112'
+spec:
+  ports:
+  - name: metrics
+    port: 2112
+    targetPort: metrics
+    protocol: TCP
+  selector:
+    {{- include "icm-web.selectorLabels" $ctx | nindent 4 }}
+status:
+  loadBalancer: {}
+{{- end }}

--- a/charts/icm-web/templates/wa-service.yaml
+++ b/charts/icm-web/templates/wa-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "icm-web.fullname" . }}-wa
+  name: {{ include "icm-web.waServiceName" . }}
   labels:
     {{- include "icm-web.labels" $ctx | nindent 4 }}
 spec:

--- a/charts/icm-web/tests/nr_test.yaml
+++ b/charts/icm-web/tests/nr_test.yaml
@@ -1,4 +1,4 @@
-suite: test correctness of environment
+suite: test correctness of new relic related resources
 templates:
   - templates/waa-deployment.yaml
   - templates/config-newrelic-yaml-cm.yaml

--- a/charts/icm-web/tests/waMonitoring_test.yaml
+++ b/charts/icm-web/tests/waMonitoring_test.yaml
@@ -1,0 +1,155 @@
+suite: test correctness of waMonitoring configuration
+templates:
+  - templates/wa-deployment.yaml
+tests:
+  - it: should inject wa-monitoring container when enabled
+    set:
+      waMonitoring.enabled: true
+      waMonitoring.image.repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+      waMonitoring.appServerUnavailableTimeout: "60s"
+      waMonitoring.scraptingInterval: "10s"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+            image: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: WA_CONFIG
+                value: "env"
+              - name: WA_TENANT
+                value: "n_a"
+              - name: WA_ENVIRONMENT
+                value: "prd-standalone"
+              - name: WA_SKIP_CERT_VALIDATION
+                value: "true"
+              - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+                value: "60s"
+              - name: WA_LOG
+                value: "/intershop/logs"
+              - name: WA_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+              - name: HTTPD_STATUS_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+              - name: SCRAPE_INTERVAL
+                value: "10s"
+            ports:
+              - containerPort: 2112
+                name: metrics
+                protocol: TCP
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            volumeMounts:
+              - mountPath: "/intershop/logs"
+                name: "logs-volume"
+
+  - it: should inject wa-monitoring container with default values
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+            image: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: WA_CONFIG
+                value: "env"
+              - name: WA_TENANT
+                value: "n_a"
+              - name: WA_ENVIRONMENT
+                value: "prd-standalone"
+              - name: WA_SKIP_CERT_VALIDATION
+                value: "true"
+              - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+                value: "30s"
+              - name: WA_LOG
+                value: "/intershop/logs"
+              - name: WA_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+              - name: HTTPD_STATUS_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+              - name: SCRAPE_INTERVAL
+                value: "5s"
+            ports:
+              - containerPort: 2112
+                name: metrics
+                protocol: TCP
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            volumeMounts:
+              - mountPath: "/intershop/logs"
+                name: "logs-volume"
+
+  - it: should inject wa-monitoring container with values from operationalContext
+    set:
+      operationalContext.customerId: "acme"
+      operationalContext.environmentType: "uat"
+      operationalContext.stagingType: "live"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+            image: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: WA_CONFIG
+                value: "env"
+              - name: WA_TENANT
+                value: "acme"
+              - name: WA_ENVIRONMENT
+                value: "uat-live"
+              - name: WA_SKIP_CERT_VALIDATION
+                value: "true"
+              - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+                value: "30s"
+              - name: WA_LOG
+                value: "/intershop/logs"
+              - name: WA_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+              - name: HTTPD_STATUS_URI
+                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+              - name: SCRAPE_INTERVAL
+                value: "5s"
+            ports:
+              - containerPort: 2112
+                name: metrics
+                protocol: TCP
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            volumeMounts:
+              - mountPath: "/intershop/logs"
+                name: "logs-volume"
+
+  - it: should not inject wa-monitoring container when disabled
+    set:
+      waMonitoring.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+
+  - it: should fail if waMonitoring.image.repository is missing
+    set:
+      waMonitoring.enabled: true
+      waMonitoring.image.repository: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "Error: missing value at waMonitoring.image.repository."

--- a/charts/icm-web/tests/waMonitoring_test.yaml
+++ b/charts/icm-web/tests/waMonitoring_test.yaml
@@ -29,9 +29,57 @@ tests:
               - name: WA_LOG
                 value: "/intershop/logs"
               - name: WA_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+                value: "http://localhost:8080/INTERSHOP/wastatistics"
               - name: HTTPD_STATUS_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+                value: "http://localhost:8080/server-status?auto"
+              - name: SCRAPE_INTERVAL
+                value: "10s"
+            ports:
+              - containerPort: 2112
+                name: metrics
+                protocol: TCP
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            volumeMounts:
+              - mountPath: "/intershop/logs"
+                name: "logs-volume"
+
+  - it: should support image tag when provided separately
+    set:
+      waMonitoring.enabled: true
+      waMonitoring.image.repository: "intershophub/icm-wa-monitoring-exporter"
+      waMonitoring.image.tag: "customTag"
+      waMonitoring.appServerUnavailableTimeout: "60s"
+      waMonitoring.scrapingInterval: "10s"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+            image: "intershophub/icm-wa-monitoring-exporter:customTag"
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: WA_CONFIG
+                value: "env"
+              - name: WA_TENANT
+                value: "n_a"
+              - name: WA_ENVIRONMENT
+                value: "prd-standalone"
+              - name: WA_SKIP_CERT_VALIDATION
+                value: "true"
+              - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+                value: "60s"
+              - name: WA_LOG
+                value: "/intershop/logs"
+              - name: WA_URI
+                value: "http://localhost:8080/INTERSHOP/wastatistics"
+              - name: HTTPD_STATUS_URI
+                value: "http://localhost:8080/server-status?auto"
               - name: SCRAPE_INTERVAL
                 value: "10s"
             ports:
@@ -55,7 +103,7 @@ tests:
           path: spec.template.spec.containers
           content:
             name: icm-web-wa-monitoring
-            image: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+            image: "intershophub/icm-wa-monitoring-exporter:1.1.0"
             imagePullPolicy: IfNotPresent
             env:
               - name: WA_CONFIG
@@ -71,9 +119,9 @@ tests:
               - name: WA_LOG
                 value: "/intershop/logs"
               - name: WA_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+                value: "http://localhost:8080/INTERSHOP/wastatistics"
               - name: HTTPD_STATUS_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+                value: "http://localhost:8080/server-status?auto"
               - name: SCRAPE_INTERVAL
                 value: "5s"
             ports:
@@ -101,7 +149,7 @@ tests:
           path: spec.template.spec.containers
           content:
             name: icm-web-wa-monitoring
-            image: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+            image: "intershophub/icm-wa-monitoring-exporter:1.1.0"
             imagePullPolicy: IfNotPresent
             env:
               - name: WA_CONFIG
@@ -117,9 +165,9 @@ tests:
               - name: WA_LOG
                 value: "/intershop/logs"
               - name: WA_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/INTERSHOP/wastatistics"
+                value: "http://localhost:8080/INTERSHOP/wastatistics"
               - name: HTTPD_STATUS_URI
-                value: "http://RELEASE-NAME-icm-web-wa:8080/server-status?auto"
+                value: "http://localhost:8080/server-status?auto"
               - name: SCRAPE_INTERVAL
                 value: "5s"
             ports:

--- a/charts/icm-web/tests/waMonitoring_test.yaml
+++ b/charts/icm-web/tests/waMonitoring_test.yaml
@@ -7,7 +7,7 @@ tests:
       waMonitoring.enabled: true
       waMonitoring.image.repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
       waMonitoring.appServerUnavailableTimeout: "60s"
-      waMonitoring.scraptingInterval: "10s"
+      waMonitoring.scrapingInterval: "10s"
     asserts:
       - contains:
           path: spec.template.spec.containers

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -94,6 +94,20 @@ webadapter:
   deploymentLabels: {}
   podLabels: {}
 
+# configure the monoring side car (exposed Prometeus metrics gathered from webadapter) for the webadapter
+waMonitoring:
+  # enable/disable the monitoring (boolean, optional, default=true)
+  enabled: true
+  image:
+    # which image to be used (docker image reference, mandatory)
+    repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+    # pull policy for the image (pullPolicy, optional, default="IfNotPresent")
+    pullPolicy: "IfNotPresent"
+  # how long to keep waStatistics related metrics available while the related app server is unavailable (syntax compatible with Go duration, optional, default="30s")
+  appServerUnavailableTimeout: 30s
+  # interval between scraping (metrics update) requests (syntax compatible with Go duration, optional, default="5s")
+  scraptingInterval: 5s
+
 agent:
   # in some REST-based environment the webadapteragent isn't mandatory
   enabled: true

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -94,7 +94,7 @@ webadapter:
   deploymentLabels: {}
   podLabels: {}
 
-# configure the monoring side car (exposed Prometeus metrics gathered from webadapter) for the webadapter
+# configure the monitoring side car (exposed Prometeus metrics gathered from webadapter) for the webadapter
 waMonitoring:
   # enable/disable the monitoring (boolean, optional, default=true)
   enabled: true

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -100,13 +100,13 @@ waMonitoring:
   enabled: true
   image:
     # which image to be used (docker image reference, mandatory)
-    repository: "intershophub/icm-wa-monitoring-exporter:1.2.0"
+    repository: "intershophub/icm-wa-monitoring-exporter:1.1.0"
     # pull policy for the image (pullPolicy, optional, default="IfNotPresent")
     pullPolicy: "IfNotPresent"
   # how long to keep waStatistics related metrics available while the related app server is unavailable (syntax compatible with Go duration, optional, default="30s")
   appServerUnavailableTimeout: 30s
   # interval between scraping (metrics update) requests (syntax compatible with Go duration, optional, default="5s")
-  scraptingInterval: 5s
+  scrapingInterval: 5s
 
 agent:
   # in some REST-based environment the webadapteragent isn't mandatory


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

No icm-wa-monitoring-exporter active
Issue Number: Closes #1219

## What Is the New Behavior?

icm-wa-monitoring-exporter running as a sidecar in the same pod as icm-wa

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
