### PR TITLE
feat(icm): support HAProxy as ingress controller (#1250)

### DIFF
--- a/.github/workflows/lint-test_icm-unittest.yml
+++ b/.github/workflows/lint-test_icm-unittest.yml
@@ -2,20 +2,32 @@ name: "Unit test icm chart"
 on:
   pull_request:
     paths:
-    - 'charts/icm/**'
+      - "charts/icm/**"
 
 jobs:
   lint-test-icm-unittest:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Base
-      uses: ./.github/template/base
-    - name: Unit test
-      uses: ./.github/template/unittest
-      with:
-        chartTestingFile: ct_icm.yaml
-        chartName: icm
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Base
+        uses: ./.github/template/base
+      - name: Add dependency chart repos
+        run: |
+          helm dependency update charts/icm-as
+          helm dependency update charts/icm
+          helm dependency update charts/icm-test
+
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add kubernetes-ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add codecentric https://codecentric.github.io/helm-charts
+          helm repo add intershop https://intershop.github.io/helm-charts
+          helm repo add mailpit https://jouve.github.io/charts/
+          helm repo add kubernetes-ingress https://haproxytech.github.io/helm-charts
+      - name: Unit test
+        uses: ./.github/template/unittest
+        with:
+          chartTestingFile: ct_icm.yaml
+          chartName: icm

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,13 +1,13 @@
 name: Release Charts
 
 on:
-  workflow_dispatch:
-  # releases the main branch
+  workflow_dispatch: # releases the main branch
+
   # the new versions must already be specified in all Chart.yaml files
   # before merging to main
   push:
     branches:
-    - main
+      - main
 
 jobs:
   release:
@@ -41,6 +41,7 @@ jobs:
           helm repo add codecentric https://codecentric.github.io/helm-charts
           helm repo add intershop https://intershop.github.io/helm-charts
           helm repo add mailpit https://jouve.github.io/charts/
+          helm repo add kubernetes-ingress https://haproxytech.github.io/helm-charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0

--- a/charts/icm-as/templates/ingress.yaml
+++ b/charts/icm-as/templates/ingress.yaml
@@ -7,9 +7,7 @@ metadata:
   labels:
     {{- include "icm-as.labels" . | nindent 4 }}
   annotations:
-    nginx.ingress.kubernetes.io/affinity: cookie
-    nginx.ingress.kubernetes.io/affinity-mode: persistent
-    nginx.ingress.kubernetes.io/session-cookie-name: stid
+    haproxy.org/cookie-persistence: stid
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/icm-as/tests/ingress_test.yaml
+++ b/charts/icm-as/tests/ingress_test.yaml
@@ -6,16 +6,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should configure sticky cookie
+  - it: should configure cookie persistence
     set:
       ingress.enabled: true
     asserts:
       - equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/affinity"]
-          value: cookie
-      - equal:
-          path: metadata.annotations["nginx.ingress.kubernetes.io/affinity-mode"]
-          value: persistent
+          path: metadata.annotations["haproxy.org/cookie-persistence"]
+          value: stid
   - it: should render additional metadata.annotations
     set:
       ingress.enabled: true
@@ -37,34 +34,34 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-      - host: foo.com
-        paths:
-        - path: /
-          pathType: Prefix
+        - host: foo.com
+          paths:
+            - path: /
+              pathType: Prefix
       ingress.tls:
-      - secretName: fooSecret
-        hosts:
-        - foo.com
+        - secretName: fooSecret
+          hosts:
+            - foo.com
     asserts:
       - equal:
           path: spec.tls
           value:
-          - secretName: fooSecret
-            hosts:
-            - foo.com
+            - secretName: fooSecret
+              hosts:
+                - foo.com
       - equal:
           path: spec.rules
           value:
-          - host: foo.com
-            http:
-              paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: RELEASE-NAME-icm-as
-                    port:
-                      name: svc
+            - host: foo.com
+              http:
+                paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: RELEASE-NAME-icm-as
+                        port:
+                          name: svc
   - it: should set default ingress name.
     set:
       ingress.enabled: true

--- a/charts/icm-web/docs/values-yaml/ingress.asciidoc
+++ b/charts/icm-web/docs/values-yaml/ingress.asciidoc
@@ -19,7 +19,7 @@ Enabling this ingress only makes sense if the link:../../../icm-as/docs/values-y
 |===
 |Attribute |Description |Type |Mandatory |Default Value
 |enabled|Enables/disables the deployment of the ingress configuration|boolean|{optional}|`false`
-|className|The name of the ingress class to be used|string|{optional}|[.placeholder]#https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class[default ingress class]#
+|className|The name of the ingress class to be used|string|{optional}|`ingress-haproxy-pub`
 |annotations|Annotations to be applied to the ingress configuration|<<_annotations,Annotations>>|{optional}|`{}`
 |hosts|Lists the hosts for the ingress rules|yaml array containing 0 to n <<_hostDefinition,HostDefinition>> objects|{mandatory}|-
 |tls|Configures the SSL/TLS termination of the processed hosts|yaml array containing 0 to n <<_tlsDefinition,TLSDefinition>> objects|{optional}|`[]`

--- a/charts/icm-web/docs/values-yaml/ingress.asciidoc
+++ b/charts/icm-web/docs/values-yaml/ingress.asciidoc
@@ -19,7 +19,7 @@ Enabling this ingress only makes sense if the link:../../../icm-as/docs/values-y
 |===
 |Attribute |Description |Type |Mandatory |Default Value
 |enabled|Enables/disables the deployment of the ingress configuration|boolean|{optional}|`false`
-|className|The name of the ingress class to be used|string|{optional}|`ingress-haproxy-pub`
+|className|The name of the ingress class to be used|string|{optional}|`ingress-haproxy`
 |annotations|Annotations to be applied to the ingress configuration|<<_annotations,Annotations>>|{optional}|`{}`
 |hosts|Lists the hosts for the ingress rules|yaml array containing 0 to n <<_hostDefinition,HostDefinition>> objects|{mandatory}|-
 |tls|Configures the SSL/TLS termination of the processed hosts|yaml array containing 0 to n <<_tlsDefinition,TLSDefinition>> objects|{optional}|`[]`

--- a/charts/icm-web/docs/values-yaml/ingress.asciidoc
+++ b/charts/icm-web/docs/values-yaml/ingress.asciidoc
@@ -86,7 +86,7 @@ The type `TLSDefinition` configures which TLS secret should be used for the assi
 ----
 ingress:
   enabled: true
-  className: icm-nginx
+  className: ingress-haproxy-pub
   annotations:
     annotation0: value0
     ...

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -240,7 +240,7 @@ resources:
 
 ingress:
   enabled: false
-  className: ingress-haproxy-pub
+  className: ingress-haproxy
   annotations: {}
   # Paths are treated as list of prefixes. Any URL matching one of the prefixes will be forwarded to ICM.
   hosts:

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -240,7 +240,7 @@ resources:
 
 ingress:
   enabled: false
-  className: nginx
+  className: ingress-haproxy-pub
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -242,10 +242,7 @@ ingress:
   enabled: false
   className: ingress-haproxy-pub
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  # Paths are treated as list of prefixes. Any URL matching one of the prefixes will
-  # be forwarded to ICM.
+  # Paths are treated as list of prefixes. Any URL matching one of the prefixes will be forwarded to ICM.
   hosts:
     - host: <dns-name-of-service>
       paths:

--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     condition: ingress-nginx.enabled
   - name: kubernetes-ingress
     alias: ingress-haproxy
-    version: 1.41.0
+    version: 1.49.0
     repository: https://haproxytech.github.io/helm-charts
     condition: ingress-haproxy.enabled
   - name: mailhog

--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -16,6 +16,10 @@ dependencies:
     version: 4.12.2
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
+  - name: kubernetes-ingress
+    version: 1.41.0
+    repository: https://haproxytech.github.io/helm-charts
+    condition: ingress-haproxy.enabled
   - name: mailhog
     version: 5.2.0
     repository: https://codecentric.github.io/helm-charts

--- a/charts/icm/Chart.yaml
+++ b/charts/icm/Chart.yaml
@@ -17,6 +17,7 @@ dependencies:
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
   - name: kubernetes-ingress
+    alias: ingress-haproxy
     version: 1.41.0
     repository: https://haproxytech.github.io/helm-charts
     condition: ingress-haproxy.enabled

--- a/charts/icm/docs/values-yaml.asciidoc
+++ b/charts/icm/docs/values-yaml.asciidoc
@@ -37,7 +37,7 @@ icm-web:
 
 ingress-haproxy:
   enabled: true
-  <ingress-nginx configuration>
+  <ingress-haproxy configuration>
 
 mailhog:
   enabled: true

--- a/charts/icm/docs/values-yaml.asciidoc
+++ b/charts/icm/docs/values-yaml.asciidoc
@@ -19,7 +19,8 @@ Therefore, the `values.yaml` contains several sections, each belonging to a spec
 |Section |Topic |Documentation
 |icm-as|ICM application server|link:../../icm-as/docs/values-yaml.asciidoc[icm-as documentation]
 |icm-web|ICM Web Adapter|link:../../icm-web/docs/values-yaml.asciidoc[icm-web documentation]
-|ingress-nginx|https://github.com/kubernetes/ingress-nginx[Ingress NGINX controller] (for development/testing purposes)|https://kubernetes.github.io/ingress-nginx[ingress-nginx documentation]
+|ingress-nginx|https://github.com/kubernetes/ingress-nginx[Ingress controller based on NGINX] (for development/testing purposes)|https://kubernetes.github.io/ingress-nginx[ingress-nginx documentation]
+|ingress-haproxy|https://www.haproxy.com/documentation/kubernetes-ingress/[Ingress controller based on HAProxy] (for development/testing purposes)|https://www.haproxy.com/documentation/kubernetes-ingress/community/installation/azure/#install-with-helm[ingress-haproxy documentation]
 |mailhog|https://github.com/mailhog/MailHog[MailHog] instance (for development/testing purposes)|https://artifacthub.io/packages/helm/codecentric/mailhog[MailHog documentation]
 |redis|Single https://redis.io/[Redis] master (page caching for Web Adapter replacement)|https://github.com/bitnami/charts/tree/main/bitnami/redis[Redis chart documentation]
 |redis-cluster|Multiple https://redis.io/[Redis] masters (page caching for Web Adapter replacement)|https://github.com/bitnami/charts/tree/main/bitnami/redis[Redis chart documentation]
@@ -34,7 +35,7 @@ icm-as:
 icm-web:
   <icm-web configuration>
 
-ingress-nginx:
+ingress-haproxy:
   enabled: true
   <ingress-nginx configuration>
 
@@ -52,7 +53,7 @@ redis-cluster:
 
 This development example deploys the following (besides `icm-as` and `icm-web`):
 
-* An Ingress NGINX controller
+* An Ingress controller based on HAProxy
 * A MailHog instance
 * A single Redis master
 

--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -120,6 +120,9 @@ icm-web:
 ingress-nginx:
   enabled: false
 
+ingress-haproxy:
+  enabled: false
+
 mailhog:
   enabled: false
 


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

Ingress controller based on NGINX is supported.

Issue Number: Closes #1250

## What Is the New Behavior?

Ingress controller based on HAProxy is supported.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

