### PR TITLE
Feature/icm/1258 non classic replication switch

### DIFF
--- a/charts/icm-as/docs/values-yaml/replication.asciidoc
+++ b/charts/icm-as/docs/values-yaml/replication.asciidoc
@@ -16,6 +16,7 @@ Configures the `icm-as-server` regarding mass data and object replication. The f
 |Attribute |Description |Type |Mandatory |Default Value
 |enabled|If `true`, the deployed ICM is a replication system|boolean|{optional}|`false`
 |role|Defines whether this `icm-as-server` is a source (_edit_) or a target (_life_) system|enum {`source`,`target`}|{mandatory}|-
+|classic|If `true`, sets `STAGING_PROCESS_CLASSIC=true` to use the classic staging process|boolean|{optional}|`true`
 |source|Configures all the connections to the source (_edit_) system|<<_source,Source>>|{mandatory}|-
 |targets|Configures all the connections to all the target (_life_) systems|<<_targets,Targets>>|{mandatory}|-
 |===

--- a/charts/icm-as/templates/_environments.tpl
+++ b/charts/icm-as/templates/_environments.tpl
@@ -218,6 +218,8 @@ Creates the environment replication section
   {{- else }}
   value: live
   {{- end }}
+- name: STAGING_PROCESS_CLASSIC
+  value: {{ .Values.replication.classic | toString | quote }}
 {{/*
 ICM-AS >= 12.2.0 supports new replication configuration via environments instead of replication-clusters.xml
 ICM-AS >= 13.0.0 requires new replication configuration

--- a/charts/icm-as/tests/replication_test.yaml
+++ b/charts/icm-as/tests/replication_test.yaml
@@ -868,7 +868,7 @@ tests:
             name: STAGING_PROCESS_CLASSIC
             value: "true"
 
-  - it: as-deployment replication.classic=true sets STAGING_PROCESS_CLASSIC to false
+  - it: as-deployment replication.classic=false sets STAGING_PROCESS_CLASSIC to false
     release:
       name: icm-as
     chart:
@@ -876,11 +876,11 @@ tests:
     values:
       - ../values.yaml
     set:
-      replication.enabled: false
+      replication.enabled: true
       replication.role: source
       replication.targetSystemUrl: https://icm-web-live-wa:443
       replication.sourceDatabaseName: intershop_edit
-      replication.classic: true
+      replication.classic: false
     template: templates/as-deployment.yaml
     asserts:
       - contains:

--- a/charts/icm-as/tests/replication_test.yaml
+++ b/charts/icm-as/tests/replication_test.yaml
@@ -847,3 +847,44 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Error: The key 'live-system' in 'replication.targets' violates the constraint that it cannot contain any of these characters: '.', '-', '_'."
+
+  - it: as-deployment replication.classic defaults to true
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: true
+      replication.role: source
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.sourceDatabaseName: intershop_edit
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_PROCESS_CLASSIC
+            value: "true"
+
+  - it: as-deployment replication.classic=true sets STAGING_PROCESS_CLASSIC to false
+    release:
+      name: icm-as
+    chart:
+      version: 0.8.15
+    values:
+      - ../values.yaml
+    set:
+      replication.enabled: false
+      replication.role: source
+      replication.targetSystemUrl: https://icm-web-live-wa:443
+      replication.sourceDatabaseName: intershop_edit
+      replication.classic: true
+    template: templates/as-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STAGING_PROCESS_CLASSIC
+            value: "false"

--- a/charts/icm-as/values.yaml
+++ b/charts/icm-as/values.yaml
@@ -535,6 +535,10 @@ replication:
   # defines the type of this replication system (source | target)
   role: <source|target>
 
+  # enables/disables the classic staging process (STAGING_PROCESS_CLASSIC=true)
+  # when true, the classic staging process is used instead of the new one
+  classic: true
+
   # "targetSystemUrl" deprecated since ICM-AS Helm Charts 2.2.0, will be removed in a future version.
   # Configure the source and targets within replication instead.
   # if role=source the following properties are mandatory (otherwise they are ignored)


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## Release

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

There is no way to enable the classic (pre-13.x) staging process via Helm values. The `STAGING_PROCESS_CLASSIC` environment variable cannot be controlled through the chart.

Issue Number: Closes #

## What Is the New Behavior?

A new boolean value `replication.classic` (default: `false`) has been added to the `icm-as` chart. When `replication.enabled` is `true`, the `STAGING_PROCESS_CLASSIC` environment variable is always rendered on the application server container, reflecting the value of `replication.classic` as `"true"` or `"false"`.

Example configuration to enable the classic staging process:

```yaml
replication:
  enabled: true
  role: source
  classic: true
```

### Files Changed

- `charts/icm-as/values.yaml` — added `replication.classic: false`
- `charts/icm-as/templates/_environments.tpl` — emit `STAGING_PROCESS_CLASSIC` unconditionally within the `replication.enabled` block
- `charts/icm-as/docs/values-yaml/replication.asciidoc` — documented the new attribute
- `charts/icm-as/tests/replication_test.yaml` — added tests for default (`false`) and explicit `true` cases

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No

## Other Information

`STAGING_PROCESS_CLASSIC` is always emitted (not only when `true`) so operators have a consistent, explicit signal of which staging process is active.