### PR TITLE
chore(icm): remove unnecessary pod annotations for cluster autoscaler (#1278)

### DIFF
--- a/charts/icm/values.yaml
+++ b/charts/icm/values.yaml
@@ -2,10 +2,6 @@ icm-as:
   podSecurityContext:
     runAsNonRoot: true
 
-  podAnnotations:
-    # as long as there are no long running job pods we need this annotation for icm-as
-    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-
   # image:
   #   repository: intershophub/icm-as
   #   tag: :11.0.12-dev1
@@ -105,9 +101,6 @@ icm-web:
     - "dockerhub"
   webadapter:
     replicaCount: 1
-    podAnnotations:
-      # as long as there is no new cache system we need this annotation for icm-web
-      "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
 
   agent:
     # in some REST-based environment the webadapteragent isn't mandatory


### PR DESCRIPTION
## PR Type

<!--
What kind of change does this PR introduce?
Please check the one that applies to this PR using "x".
-->

- [x] Bugfix
- [x] Application / infrastructure changes

## Release ##

Be sure that pull requests are build according to the defined release process [here](https://github.com/intershop/helm-charts/wiki/Release-Process). As a main part to mention here is that the semantic version type will be read from the commit messages (`BREAKING CHANGE(icm):` marks a *major* change, `feat(icm):` marks *minor* changes and the rest will be *patch*. So the developer must already know and is responsible.

## What Is the Current Behavior?

Current default ICM settings prevent potentially unnecessary nodes from being removed and cluster node pools from being in-scaled. This only affects all ICM workloads (AS, WA, WAA) while IOM/PWA are not having this set. 

Issue Number: Closes #1278

## What Is the New Behavior?

Default ICM settings will not include save-to-evict podAnnotation.

## Does this PR Introduce a Breaking Change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No