### PR TITLE
feat(icm): support config of urlmapping prefix (#1296)

### DIFF
--- a/charts/icm-web/docs/values-yaml/no-section.asciidoc
+++ b/charts/icm-web/docs/values-yaml/no-section.asciidoc
@@ -15,6 +15,7 @@
 |<<_example_nameOverride,fullnameOverride>>|Overrides the names/prefix of the several deployed resources which normally is calculated from chart and release name|string|{optional}|[.placeholder]#empty string#
 |<<_example_nameOverride,nameOverride>>|Overrides the name used for label `app.kubernetes.io/name` which normally is calculated from chart name|string|{optional}|[.placeholder]#empty string#
 |<<_example_nodeSelector,nodeSelector>>|https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[Node selector configuration]|yaml object|{optional}|`{}`
+|<<_example_urlMappingPrefix,urlMappingPrefix>>|Overrides the URL mapping prefix expected to be used by the link:../../../icm-as/docs/values-yaml.asciidoc[icm-as]|string (incl. leading `/`)|{optional}|`/INTERSHOP`
 |===
 
 == Examples
@@ -136,4 +137,22 @@ spec:
 [CAUTION]
 ====
 When node selectors are used, the attribute `webadapter.schedulePodsPreferredEvenlyAcrossNodes` is ignored so the node selection rules defined by `nodeSelector` are applied.
+====
+
+[#_example_urlMappingPrefix]
+=== urlMappingPrefix
+
+Configuring `urlMappingPrefix` like this:
+[source,yaml]
+----
+urlMappingPrefix: "/MYCUSTOMPREFIX"
+----
+will result in:
+
+* the Web Adapter using this prefix for its readiness probe
+* the link:wa-monitoring.asciidoc[Web Adapter Monitoring] sidecar to access the Web Adapter using this prefix
+
+[CAUTION]
+====
+When configuring the `urlMappingPrefix` using a different then its default value you also need to use the same prefix for the link:../../../icm-as/docs/values-yaml.asciidoc[icm-as] configuration.
 ====

--- a/charts/icm-web/templates/_urlMappingPrefix.tpl
+++ b/charts/icm-web/templates/_urlMappingPrefix.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Renders the urlMappingPrefix
+*/}}
+
+{{- define "icm-web.urlMappingPrefix" -}}
+  {{- .Values.urlMappingPrefix | default "/INTERSHOP" -}}
+{{- end -}}
+
+{{- define "icm-web.urlMappingPrefixFull" -}}
+  {{- printf "%s/wastatus" (include "icm-web.urlMappingPrefix" . ) | quote -}}
+{{- end -}}
+

--- a/charts/icm-web/templates/_urlMappingPrefix.tpl
+++ b/charts/icm-web/templates/_urlMappingPrefix.tpl
@@ -5,10 +5,10 @@ Renders the urlMappingPrefix
 */}}
 
 {{- define "icm-web.urlMappingPrefix" -}}
-  {{- .Values.urlMappingPrefix | default "/INTERSHOP" -}}
+  {{- $prefix := .Values.urlMappingPrefix | default "/INTERSHOP" -}}
+  {{- ternary $prefix (printf "/%s" $prefix) (hasPrefix "/" $prefix) -}}
 {{- end -}}
 
 {{- define "icm-web.urlMappingPrefixFull" -}}
   {{- printf "%s/wastatus" (include "icm-web.urlMappingPrefix" . ) | quote -}}
 {{- end -}}
-

--- a/charts/icm-web/templates/_waMonitoringExporter.tpl
+++ b/charts/icm-web/templates/_waMonitoringExporter.tpl
@@ -25,7 +25,7 @@
   - name: WA_LOG
     value: "/intershop/logs"
   - name: WA_URI
-    value: "http://localhost:8080/INTERSHOP/wastatistics"
+    value: {{- printf "http://localhost:8080%s/wastatistics" (include "icm-web.urlMappingPrefix" . ) | indent 1 }}
   - name: HTTPD_STATUS_URI
     value: "http://localhost:8080/server-status?auto"
   - name: SCRAPE_INTERVAL

--- a/charts/icm-web/templates/wa-deployment.yaml
+++ b/charts/icm-web/templates/wa-deployment.yaml
@@ -198,7 +198,7 @@ spec:
             httpGet:
               # /INTERSHOP/wastatus response code is directly linked to configuration servlet availability/validity and
               # therefore ultimately linked to ICM-AS readiness
-              path: /INTERSHOP/wastatus
+              path: {{- include "icm-web.urlMappingPrefixFull" . | indent 1 }}
               port: {{ .Values.service.httpPort }}
               httpHeaders:
                 - name: X-HEALTHCHECK

--- a/charts/icm-web/tests/waMonitoring_test.yaml
+++ b/charts/icm-web/tests/waMonitoring_test.yaml
@@ -185,6 +185,50 @@ tests:
               - mountPath: "/intershop/logs"
                 name: "logs-volume"
 
+  - it: should inject wa-monitoring container with value from urlMappingPrefix
+    set:
+      urlMappingPrefix: "/CUSTOMPREFIX"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: icm-web-wa-monitoring
+            image: "intershophub/icm-wa-monitoring-exporter:1.1.0"
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: WA_CONFIG
+                value: env
+              - name: WA_TENANT
+                value: n_a
+              - name: WA_ENVIRONMENT
+                value: prd-standalone
+              - name: WA_SKIP_CERT_VALIDATION
+                value: "true"
+              - name: WA_APP_SERVER_UNAVAILABLE_TIMEOUT
+                value: 30s
+              - name: WA_LOG
+                value: /intershop/logs
+              - name: WA_URI
+                value: http://localhost:8080/CUSTOMPREFIX/wastatistics
+              - name: HTTPD_STATUS_URI
+                value: http://localhost:8080/server-status?auto
+              - name: SCRAPE_INTERVAL
+                value: 5s
+            ports:
+              - containerPort: 2112
+                name: metrics
+                protocol: TCP
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 100Mi
+            volumeMounts:
+              - mountPath: "/intershop/logs"
+                name: "logs-volume"
+
   - it: should not inject wa-monitoring container when disabled
     set:
       waMonitoring.enabled: false

--- a/charts/icm-web/values.yaml
+++ b/charts/icm-web/values.yaml
@@ -94,6 +94,9 @@ webadapter:
   deploymentLabels: {}
   podLabels: {}
 
+  # Customize the prefix used in typical icm-as URLs e.g. the /INTERSHOP in https://store.company.com/INTERSHOP/web/WFS/inSPIRED-inTRONICS-Site/en_US/-/USD/
+  urlMappingPrefix: "/INTERSHOP"
+
 # configure the monitoring side car (exposed Prometeus metrics gathered from webadapter) for the webadapter
 waMonitoring:
   # enable/disable the monitoring (boolean, optional, default=true)


### PR DESCRIPTION
## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Application / infrastructure changes

## What Is the Current Behavior?

URL mapping prefix can not be configured (is always `INTERSHOP`).

Issue Number: Closes #1296 

## What Is the New Behavior?

URL mapping prefix can be configured.

## Does this PR Introduce a Breaking Change?

- [ ] Yes
- [x] No
